### PR TITLE
Update README and add in Dockerfile for building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM ubuntu:18.04
+
+RUN apt-get update && apt-get install -y git wget libncurses-dev flex bison gperf \
+  python python-pip python-setuptools python-serial python-click \
+  python-cryptography python-future python-pyparsing \
+  python-pyelftools cmake ninja-build ccache libusb-1.0
+
+RUN mkdir /workspace
+WORKDIR /workspace
+
+# Download and checkout known good esp-idf commit
+RUN git clone --recursive https://github.com/espressif/esp-idf.git esp-idf
+RUN cd esp-idf && git checkout 4dac7c7df885adaa86a5c79f2adeaf8d68667349
+RUN git clone https://github.com/sle118/squeezelite-esp32.git
+
+# Download GCC 5.2.0
+RUN wget https://dl.espressif.com/dl/xtensa-esp32-elf-linux64-1.22.0-80-g6c4433a-5.2.0.tar.gz
+RUN tar -xzf xtensa-esp32-elf-linux64-1.22.0-80-g6c4433a-5.2.0.tar.gz
+RUN rm xtensa-esp32-elf-linux64-1.22.0-80-g6c4433a-5.2.0.tar.gz
+
+# Patch I2S in esp-idf
+RUN cp /workspace/squeezelite-esp32/idf-patch/i2s.c /workspace/esp-idf/components/driver/i2s.c
+RUN rm -r /workspace/squeezelite-esp32
+RUN mkdir /workspace/squeezelite-esp32
+
+# Setup PATH to use esp-idf and gcc-5.2.0
+RUN touch /root/.bashrc && \
+ echo export PATH="\$PATH:/workspace/xtensa-esp32-elf/bin" >> /root/.bashrc && \
+ echo export IDF_PATH=/workspace/esp-idf >> /root/.bashrc
+
+# OPTIONAL: Install vim for text editing in Bash
+RUN apt-get update && apt-get install -y vim
+
+WORKDIR /workspace/squeezelite-esp32
+CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -2,15 +2,36 @@
 <strong>Currently this project requires a specific combination of IDF 4 with gcc 5.2. You'll have to implement the gcc 5.2 toolchain from an IDF 3.2 install into the IDF 4 directory in order to successfully compile it</strong>
 *********************
 
-	
+## Setting up ESP-IDF
+
+### Docker
+You can use docker to build squeezelite-esp32
+First you need to build the Docker container:
+```
+docker build -t esp-idf .
+```
+Then you need to run the container:
+```
+docker run -i -t -v `pwd`:/workspace/squeezelite-esp32 esp-idf
+```
+The above command will mount this repo into the docker container and start a bash terminal
+for you to then follow the below build steps
+
+### Manual Install of ESP-IDF
+You can install IDF manually on Linux or Windows (using the Subsystem for Linux) following the instructions at: https://www.instructables.com/id/ESP32-Development-on-Windows-Subsystem-for-Linux/
+And then copying the i2s.c patch file from this repo over to the esp-idf folder
+
+## Building Repo
+
 TODO
 - when IP changes, best is to reboot at this point
 
 MOST IMPORTANT: create the right default config file
 - make defconfig
-Then adapt the config file to your wifi/BT/I2C device (can alos be done on the command line)
+(Note: You can also copy over config files from the build-scripts folder to ./sdkconfig)
+Then adapt the config file to your wifi/BT/I2C device (can also be done on the command line)
 - make menuconfig
-Then 
+Then
 - make -j4
 - make flash monitor
 
@@ -44,11 +65,11 @@ The "join" and "squeezelite" commands can also be typed at the prompt to start m
 The squeezelite options are very similar to the regular Linux ones. Differences are :
 
 	- the output is -o [\"BT -n '<sinkname>' \"] | [I2S]
-	
+
 	- if you've compiled with RESAMPLE option, normal soxr options are available using -R [-u <options>]. Note that anything above LQ or MQ will overload the CPU
-	
+
 	- if you've used RESAMPLE16, <options> are (b|l|m)[:i], with b = basic linear interpolation, l = 13 taps, m = 21 taps, i = interpolate filter coefficients
-	
+
 To add options that require quotes ("), escape them with \\". For example, so use a BT speaker named MySpeaker, accept audio up to 192kHz and resample everything to 44100 and use 16 bits resample with medium quality, the command line is:
 
 nvs_set autoexec2 str -v "squeezelite -o \\"BT -n 'BT \<sinkname\>'\\" -b 500:2000 -R -u m -Z 192000 -r \"44100-44100\"
@@ -61,17 +82,17 @@ See squeezlite command line, but keys options are
 
 # Additional misc notes to do you build
 - as of this writing, ESP-IDF has a bug int he way the PLL values are calculated for i2s, so you *must* use the i2s.c file in the patch directory
-- for all libraries, add -mlongcalls. 
+- for all libraries, add -mlongcalls.
 - audio libraries are complicated to rebuild, open an issue if you really want to
 - libmad, libflac (no esp's version), libvorbis (tremor - not esp's version), alac work
 - libfaad does not really support real time, but if you want to try
 	- -O3 -DFIXED_POINT -DSMALL_STACK
 	- change ac_link in configure and case ac_files, remove ''
-	- compiler but in cfft.c and cffti1, must disable optimization using 
+	- compiler but in cfft.c and cffti1, must disable optimization using
 			#pragma GCC push_options
 			#pragma GCC optimize ("O0")
 			#pragma GCC pop_options
-- opus & opusfile 
+- opus & opusfile
 	- for opus, the ESP-provided library seems to work, but opusfile is still needed
 	- per mad & few others, edit configure and change $ac_link to add -c (faking link)
 	- change ac_files to remove ''
@@ -80,11 +101,10 @@ See squeezlite command line, but keys options are
 - set IDF_PATH=/home/esp-idf
 - set ESPPORT=COM9
 - update flash partition size
-- other compiler #define 
+- other compiler #define
 	- use no resampling or set RESAMPLE (soxr) or set RESAMPLE16 for fast fixed 16 bits resampling
 	- use LOOPBACK (mandatory)
 	- use BYTES_PER_FRAME=4 (8 is not fully functionnal)
 	- LINKALL (mandatory)
 	- NO_FAAD unless you want to us faad, which currently overloads the CPU
 	- TREMOR_ONLY (mandatory)
-	


### PR DESCRIPTION
Updates the README to slightly better detail how to get a working ESP-IDF build system. 
Also includes a Dockerfile for generating a docker container with a working build system in.