### PR TITLE
Make the EQ in player settings update the player in "real time"

### DIFF
--- a/plugin/SqueezeESP32/HTML/EN/plugins/SqueezeESP32/settings/player.html
+++ b/plugin/SqueezeESP32/HTML/EN/plugins/SqueezeESP32/settings/player.html
@@ -39,8 +39,35 @@
 	[% END %]
 
 	[% WRAPPER setting title="PLUGIN_SQUEEZEESP32_EQUALIZER" desc="" %]
+		<div>[% "PLUGIN_SQUEEZEESP32_EQUALIZER_SAVE" | string %]</div>
 	[% END %]
 
+	<script TYPE="text/javascript">
+		if (Ext) {
+			Ext.onReady(function () {
+				new Ext.util.TaskRunner().start({
+					run: checkEq,
+					interval: 1000
+				});
+			});
+
+			function checkEq() {
+				var eqValues = [];
+				this.lastValues = this.lastValues || [];
+
+				for (var x = 0; x < 10; x++) {
+					eqValues[x] = Ext.get('pref_equalizer.' + x).dom.value || 0;
+				}
+
+				if (eqValues.join() != this.lastValues.join()) {
+					this.lastValues = eqValues;
+					SqueezeJS.Controller.request({
+						params: ['[% playerid %]', ['squeezeesp32', 'seteq', eqValues.join()]]
+					});
+				}
+			}
+		}
+	</script>
 	[% WRAPPER settingSection %]
 		[% WRAPPER settingGroup title='31Hz' desc="" %]
 			<input type="text" class="stdedit sliderInput_-13_20" name="pref_equalizer.0" id="pref_equalizer.0" value="[% pref_equalizer.0 %]" size="2"">

--- a/plugin/SqueezeESP32/strings.txt
+++ b/plugin/SqueezeESP32/strings.txt
@@ -97,3 +97,6 @@ PLUGIN_SQUEEZEESP32_EQUALIZER
 	DE	Parametrischer Equalizer
 	EN	Parametric equalizer
 
+PLUGIN_SQUEEZEESP32_EQUALIZER_SAVE
+	DE	Bitte speichern Sie die Equalizer Einstellungen, falls das Gerät diese dauerhaft verwenden soll. Ansonsten werden sie beim nächsten Start zurückgesetzt.
+	EN	Don't forget to save the Equalizer settings if you want them to stick. Otherwise they'll be reset next time you restart the device.


### PR DESCRIPTION
When you change EQ settings you have to press `Save` all the time to hear the changes. With this new feature the EQ would be updated in "real time" (every second). Which allows you to hear changes while you apply them. Only once you're happy and hit `Save` the EQ settings will be stored. Otherwise the player will revert to previous settings upon next start.

This change adds a CLI command:

```
squeezeesp32 seteq 3,2,1,0,0,0,0,0,0,1
```

The values of the EQ are passed as a comma separated list.