### PR TITLE
The SqueezeESP32 plugin requires LMS 7.9. It wouldn't run on 7.7.

### DIFF
--- a/plugin/SqueezeESP32/Plugin.pm
+++ b/plugin/SqueezeESP32/Plugin.pm
@@ -13,7 +13,7 @@ my $prefs = preferences('plugin.squeezeesp32');
 my $log = Slim::Utils::Log->addLogCategory({
 	'category'     => 'plugin.squeezeesp32',
 	'defaultLevel' => 'INFO',
-	'description'  => Slim::Utils::Strings::string('SqueezeESP32'),
+	'description'  => 'PLUGIN_SQUEEZEESP32',
 });
 
 # migrate 'eq' pref, as that's a reserved word and could cause problems in the future

--- a/plugin/SqueezeESP32/install.xml
+++ b/plugin/SqueezeESP32/install.xml
@@ -3,7 +3,7 @@
   <defaultState>enabled</defaultState>
   <email>philippe_44@outlook.com</email>
   <targetApplication>
-    <minVersion>7.5</minVersion>
+    <minVersion>7.9</minVersion>
     <maxVersion>*</maxVersion>
     <id>SlimServer</id>
   </targetApplication>


### PR DESCRIPTION
Don't even install it on older LMS. ImageProxy and `addPlayerClass` are 7.9+ only.