### PR TITLE
Add Attenuation parameter to battery service

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,9 +361,9 @@ The benefit of the "raw" mode is that you can build a player which is as close a
 There is no good or bad option, it's your choice. Use the NVS parameter "lms_ctrls_raw" to change that option
 
 ### Battery / ADC
-The NVS parameter "bat_config" sets the ADC1 channel used to measure battery/DC voltage. Scale is a float ratio applied to every sample of the 12 bits ADC. A measure is taken every 10s and an average is made every 5 minutes (not a sliding window). Syntax is
+The NVS parameter "bat_config" sets the ADC1 channel used to measure battery/DC voltage. The "atten" value attenuates the input voltage to the ADC input (the read value maintains a 0-1V rage) where: 0=no attenuation(0..800mV), 1=2.5dB attenuation(0..1.1V), 2=6dB attenuation(0..1.35V), 3=11dB attenuation(0..2.6V). Scale is a float ratio applied to every sample of the 12 bits ADC. A measure is taken every 10s and an average is made every 5 minutes (not a sliding window). Syntax is
 ```
-channel=0..7,scale=<scale>,cells=<2|3>
+channel=0..7,scale=<scale>,cells=<2|3>,[atten=<0|1|2|3>]
 ```
 NB: Set parameter to empty to disable battery reading. For well-known configuration, this is ignored (except for SqueezeAMP where number of cells is required)
 # Configuration

--- a/components/services/battery.c
+++ b/components/services/battery.c
@@ -32,8 +32,8 @@ static const char *TAG = "battery";
 static struct {
 	int channel;
 	float sum, avg, scale;
-	int count, attenuation;
-	int cells;
+	int count;
+	int cells, attenuation;
 	TimerHandle_t timer;
 } battery = {
 	.channel = CONFIG_BAT_CHANNEL,

--- a/components/services/battery.c
+++ b/components/services/battery.c
@@ -32,12 +32,13 @@ static const char *TAG = "battery";
 static struct {
 	int channel;
 	float sum, avg, scale;
-	int count;
+	int count, attenuation;
 	int cells;
 	TimerHandle_t timer;
 } battery = {
 	.channel = CONFIG_BAT_CHANNEL,
 	.cells = 2,
+	.attenuation = ADC_ATTEN_DB_0,
 };	
 
 /****************************************************************************************
@@ -82,6 +83,7 @@ void battery_svc_init(void) {
 #ifndef CONFIG_BAT_LOCKED		
 		if ((p = strcasestr(nvs_item, "channel")) != NULL) battery.channel = atoi(strchr(p, '=') + 1);
 		if ((p = strcasestr(nvs_item, "scale")) != NULL) battery.scale = atof(strchr(p, '=') + 1);
+		if ((p = strcasestr(nvs_item, "atten")) != NULL) battery.attenuation = atoi(strchr(p, '=') + 1);
 #endif		
 		if ((p = strcasestr(nvs_item, "cells")) != NULL) battery.cells = atof(strchr(p, '=') + 1);		
 		free(nvs_item);
@@ -89,7 +91,7 @@ void battery_svc_init(void) {
 
 	if (battery.channel != -1) {
 		adc1_config_width(ADC_WIDTH_BIT_12);
-		adc1_config_channel_atten(battery.channel, ADC_ATTEN_DB_0);
+		adc1_config_channel_atten(battery.channel, battery.attenuation);
 
 		battery.avg = adc1_get_raw(battery.channel) * battery.scale / 4095.0;    
 		battery.timer = xTimerCreate("battery", BATTERY_TIMER / portTICK_RATE_MS, pdTRUE, NULL, battery_callback);


### PR DESCRIPTION
On-going changes to support TTGO TAudio device

This is a simple change to enable a larger range to the ADC battery sensor.  The TAudio applies up to 1.7V to the battery pin (ADC1_7/IO35), so requires attenuation to prevent saturation.
