### PR TITLE
fix audio control in bt and airplay

### DIFF
--- a/components/driver_bt/bt_app_sink.c
+++ b/components/driver_bt/bt_app_sink.c
@@ -133,12 +133,14 @@ static void bt_next(bool pressed) {
 }
 
 const static actrls_t controls = {
+    NULL, // power
 	bt_volume_up, bt_volume_down,	// volume up, volume down
 	bt_toggle, bt_play,	// toggle, play
 	bt_pause, bt_stop,	// pause, stop
 	NULL, NULL,			// rew, fwd
 	bt_prev, bt_next,	// prev, next
 	NULL, NULL, NULL, NULL, // left, right, up, down
+    NULL, NULL, NULL, NULL, NULL, NULL, // pre1-6
 	bt_volume_down, bt_volume_up, bt_toggle// knob left, knob_right, knob push
 };
 

--- a/components/driver_bt/bt_app_sink.c
+++ b/components/driver_bt/bt_app_sink.c
@@ -133,14 +133,14 @@ static void bt_next(bool pressed) {
 }
 
 const static actrls_t controls = {
-    NULL, // power
+        NULL, // power
 	bt_volume_up, bt_volume_down,	// volume up, volume down
 	bt_toggle, bt_play,	// toggle, play
 	bt_pause, bt_stop,	// pause, stop
 	NULL, NULL,			// rew, fwd
 	bt_prev, bt_next,	// prev, next
 	NULL, NULL, NULL, NULL, // left, right, up, down
-    NULL, NULL, NULL, NULL, NULL, NULL, // pre1-6
+        NULL, NULL, NULL, NULL, NULL, NULL, // pre1-6
 	bt_volume_down, bt_volume_up, bt_toggle// knob left, knob_right, knob push
 };
 

--- a/components/driver_bt/bt_app_sink.c
+++ b/components/driver_bt/bt_app_sink.c
@@ -133,14 +133,14 @@ static void bt_next(bool pressed) {
 }
 
 const static actrls_t controls = {
-        NULL, // power
+	NULL, // power
 	bt_volume_up, bt_volume_down,	// volume up, volume down
 	bt_toggle, bt_play,	// toggle, play
 	bt_pause, bt_stop,	// pause, stop
 	NULL, NULL,			// rew, fwd
 	bt_prev, bt_next,	// prev, next
 	NULL, NULL, NULL, NULL, // left, right, up, down
-        NULL, NULL, NULL, NULL, NULL, NULL, // pre1-6
+	NULL, NULL, NULL, NULL, NULL, NULL, // pre1-6
 	bt_volume_down, bt_volume_up, bt_toggle// knob left, knob_right, knob push
 };
 

--- a/components/raop/raop_sink.c
+++ b/components/raop/raop_sink.c
@@ -81,12 +81,14 @@ static void raop_next(bool pressed) {
 }
 
 const static actrls_t controls = {
+	NULL,								// power
 	raop_volume_up, raop_volume_down,	// volume up, volume down
 	raop_toggle, raop_play,				// toggle, play
 	raop_pause, raop_stop,				// pause, stop
 	NULL, NULL,							// rew, fwd
 	raop_prev, raop_next,				// prev, next
 	NULL, NULL, NULL, NULL, // left, right, up, down
+	NULL, NULL, NULL, NULL, NULL, NULL, NULL, // pre1-6
 	raop_volume_down, raop_volume_up, raop_toggle// knob left, knob_right, knob push
 };
 

--- a/components/services/audio_controls.c
+++ b/components/services/audio_controls.c
@@ -55,6 +55,7 @@ static const actrls_config_map_t actrls_config_map[] =
 		};
 
 // BEWARE: the actions below need to stay aligned with the corresponding enum to properly support json parsing
+//   along with the actrls_t controls in LMS_controls, bt_sink and raop_sink
 #define EP(x) [x] = #x  /* ENUM PRINT */
 static const char * actrls_action_s[ ] = { EP(ACTRLS_POWER),EP(ACTRLS_VOLUP),EP(ACTRLS_VOLDOWN),EP(ACTRLS_TOGGLE),EP(ACTRLS_PLAY),
 									EP(ACTRLS_PAUSE),EP(ACTRLS_STOP),EP(ACTRLS_REW),EP(ACTRLS_FWD),EP(ACTRLS_PREV),EP(ACTRLS_NEXT),


### PR DESCRIPTION
This PR fixes a bug where button and rotary controls in bt-sink mode  do not function as expected.  Added corresponding fix for airplay, but not tested. 
I assume it was introduced with commit 347a795 (add power and preset buttons).