### PR TITLE
Allow SPI mode to be configured for SPI displays.

### DIFF
--- a/components/display/core/gds_default_if.h
+++ b/components/display/core/gds_default_if.h
@@ -11,7 +11,7 @@ bool GDS_I2CInit( int PortNumber, int SDA, int SCL, int speed );
 bool GDS_I2CAttachDevice( struct GDS_Device* Device, int Width, int Height, int I2CAddress, int RSTPin, int BacklightPin );
 
 bool GDS_SPIInit( int SPI, int DC );
-bool GDS_SPIAttachDevice( struct GDS_Device* Device, int Width, int Height, int CSPin, int RSTPin, int Speed, int BacklightPin );
+bool GDS_SPIAttachDevice( struct GDS_Device* Device, int Width, int Height, int CSPin, int RSTPin, int Speed, int BacklightPin, int Mode );
 
 #ifdef __cplusplus
 }

--- a/components/display/core/ifaces/default_if_spi.c
+++ b/components/display/core/ifaces/default_if_spi.c
@@ -34,7 +34,7 @@ bool GDS_SPIInit( int SPI, int DC ) {
     return true;
 }
 
-bool GDS_SPIAttachDevice( struct GDS_Device* Device, int Width, int Height, int CSPin, int RSTPin, int BackLightPin, int Speed ) {
+bool GDS_SPIAttachDevice( struct GDS_Device* Device, int Width, int Height, int CSPin, int RSTPin, int BackLightPin, int Speed, int Mode ) {
     spi_device_interface_config_t SPIDeviceConfig = { };
     spi_device_handle_t SPIDevice;
 
@@ -48,13 +48,14 @@ bool GDS_SPIAttachDevice( struct GDS_Device* Device, int Width, int Height, int 
     SPIDeviceConfig.clock_speed_hz = Speed > 0 ? Speed : SPI_MASTER_FREQ_8M;
     SPIDeviceConfig.spics_io_num = CSPin;
     SPIDeviceConfig.queue_size = 1;
-	SPIDeviceConfig.flags = SPI_DEVICE_NO_DUMMY;
-	if (Device->SPIParams) Device->SPIParams(SPIDeviceConfig.clock_speed_hz, &SPIDeviceConfig.mode, 
-											 &SPIDeviceConfig.cs_ena_pretrans, &SPIDeviceConfig.cs_ena_posttrans);
+    SPIDeviceConfig.mode = Mode;
+
+    SPIDeviceConfig.flags = SPI_DEVICE_NO_DUMMY;
+    if (Device->SPIParams) Device->SPIParams(SPIDeviceConfig.clock_speed_hz, &SPIDeviceConfig.mode, &SPIDeviceConfig.cs_ena_pretrans, &SPIDeviceConfig.cs_ena_posttrans);
 	
     ESP_ERROR_CHECK_NONFATAL( spi_bus_add_device( SPIHost, &SPIDeviceConfig, &SPIDevice ), return false );
 	
-	Device->WriteCommand = SPIDefaultWriteCommand;
+    Device->WriteCommand = SPIDefaultWriteCommand;
     Device->WriteData = SPIDefaultWriteData;
     Device->SPIHandle = SPIDevice;
     Device->RSTPin = RSTPin;

--- a/components/display/display.c
+++ b/components/display/display.c
@@ -119,14 +119,15 @@ void display_init(char *welcome) {
 		
 			ESP_LOGI(TAG, "Display is I2C on port %u", address);
 		} else if (strcasestr(config, "SPI") && spi_system_host != -1) {
-			int CS_pin = -1, speed = 0;
+			int CS_pin = -1, speed = 0, mode = 0;
 		
 			PARSE_PARAM(config, "cs", '=', CS_pin);
 			PARSE_PARAM(config, "speed", '=', speed);
+			PARSE_PARAM(config, "spimode", '=', mode);
 		
 			init = true;
 			GDS_SPIInit( spi_system_host, spi_system_dc_gpio );
-			GDS_SPIAttachDevice( display, width, height, CS_pin, RST_pin, backlight_pin, speed );
+			GDS_SPIAttachDevice( display, width, height, CS_pin, RST_pin, backlight_pin, speed, mode );
 				
 			ESP_LOGI(TAG, "Display is SPI host %u with cs:%d", spi_system_host, CS_pin);
 		} else {


### PR DESCRIPTION
### Observation
Some SPI displays require a different ESP32 SPI mode to operate properly, e.g. ST7789 derivatives.

### Changes
NVS variable "display_config" receives new option "spimode", e.g.

`display_config=SPI,width=240,height=240,reset=22,back=4,speed=10000000,driver=ST7789,HFlip,VFlip,spimode=3`

spimode is an integer value (range: 0 to 3).

### Explanations
spimode is an integer value between 0 and 3 as used in `struct spi_device_interface_config_t`.

According to ESP IDF documentation: 
> SPI mode, representing a pair of (CPOL, CPHA) configuration

If spimode is not provided in NVS variable "display_config", it is set to the default value of 0.

### Caveats
- spimode is not checked for invalid values.
- Side effects for SPI gpio expanders were not investigated. It is not clear whether it is a problem to use different SPI modes for SPI expanders and SPI displays.