### PR TITLE
Bluetooth Source mods

### DIFF
--- a/components/driver_bt/bt_app_core.c
+++ b/components/driver_bt/bt_app_core.c
@@ -114,6 +114,14 @@ static void bt_app_task_handler(void *arg)
     esp_bt_gap_set_security_param(param_type, &iocap, sizeof(uint8_t));
 #endif
 	
+    /*
+     * Set default parameters for Legacy Pairing
+     * Use variable pin, input pin code when pairing
+     */
+    esp_bt_pin_type_t pin_type = ESP_BT_PIN_TYPE_VARIABLE;
+    esp_bt_pin_code_t pin_code;
+    esp_bt_gap_set_pin(pin_type, 0, pin_code);
+	
 	running = true;
 	
 	while (running) {

--- a/components/driver_bt/bt_app_source.c
+++ b/components/driver_bt/bt_app_source.c
@@ -672,9 +672,9 @@ static void filter_inquiry_scan_result(esp_bt_gap_cb_param_t *param)
     	ESP_LOGV(TAG,"--Invalid class of device. Skipping.\n");
     	return;
     }
-    else if (!(esp_bt_gap_get_cod_srvc(cod) & ESP_BT_COD_SRVC_RENDERING))
+    else if (!(esp_bt_gap_get_cod_srvc(cod) & (ESP_BT_COD_SRVC_RENDERING | ESP_BT_COD_SRVC_AUDIO)))
     {
-    	ESP_LOGV(TAG,"--Not a rendering device. Skipping.\n");
+    	ESP_LOGV(TAG,"--Not a rendering or audio device. Skipping.\n");
     	return;
     }
 


### PR DESCRIPTION
This PR pushes the #100 class of service mod that I have been using on my builds without issue for the past few years.   

The legacy pairing mod, seems to help with re-connection of some of the bt-speakers I have been using while debugging.  Mod comes from the Expressif example code (idf 4.3.2).   