### PR TITLE
Fix i2s pin displays

### DIFF
--- a/components/services/accessors.c
+++ b/components/services/accessors.c
@@ -105,11 +105,14 @@ bool is_spdif_config_locked(){
  * Set pin from config string
  */
 static void set_i2s_pin(char *config, i2s_pin_config_t *pin_config) {
-	char *p;
-	pin_config->bck_io_num = pin_config->ws_io_num = pin_config->data_out_num = pin_config->data_in_num = -1; 				
-	if ((p = strcasestr(config, "bck"))) sscanf(p, "bck%*[^=]=%d", &pin_config->bck_io_num);
-	if ((p = strcasestr(config, "ws"))) sscanf(p, "ws%*[^=]=%d", &pin_config->ws_io_num);
-	if ((p = strcasestr(config, "do"))) sscanf(p, "do%*[^=]=%d", &pin_config->data_out_num);
+	pin_config->bck_io_num = pin_config->ws_io_num = pin_config->data_out_num = pin_config->data_in_num = -1;
+	PARSE_PARAM(config, "bck", '=', pin_config->bck_io_num);
+	PARSE_PARAM(config, "ws", '=', pin_config->ws_io_num);
+	PARSE_PARAM(config, "do", '=', pin_config->data_out_num);
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 4, 0)
+    pin_config->mck_io_num = strcasestr(config, "mck") ? 0 : -1;
+    PARSE_PARAM(config, "mck", '=', pin_config->mck_io_num);   
+#endif    
 }
 
 /****************************************************************************************


### PR DESCRIPTION
Addresses the SPDIF (and DAC) Hardware form issues  in #277 

With the redirect fix (thanks to @philippe44 and commit d7706e), I was able to figure out the old regex  in `set_i2s_pin` was not working.  This PR just copies the previously fixed function from `output_i2s.c`.

I looked at sharing the static, but this is the less risk solution.