### PR TITLE
Allow offset on ST7789

### DIFF
--- a/components/display/ST77xx.c
+++ b/components/display/ST77xx.c
@@ -289,10 +289,8 @@ struct GDS_Device* ST77xx_Detect(char *Driver, struct GDS_Device* Device) {
 	struct PrivateSpace* Private = (struct PrivateSpace*) Device->Private;
 	Private->Model = Model;
 
-	if (Model == ST7735) {
-		sscanf(Driver, "%*[^:]%*[^x]%*[^=]=%hu", &Private->Offset.Height);		
-		sscanf(Driver, "%*[^:]%*[^y]%*[^=]=%hu", &Private->Offset.Width);		
-	}
+	sscanf(Driver, "%*[^:]%*[^x]%*[^=]=%hu", &Private->Offset.Height);		
+	sscanf(Driver, "%*[^:]%*[^y]%*[^=]=%hu", &Private->Offset.Width);		
 	
 	if (Depth == 18) {
 		Device->Mode = GDS_RGB666;


### PR DESCRIPTION
remove ST7735 restriction on x and y offsets to support ST7789 320x170 display that needs `:x=35`