### PR TITLE
Support for ESP32S3 RMT channel restrictions

### DIFF
--- a/components/led_strip/led_vu.c
+++ b/components/led_strip/led_vu.c
@@ -97,7 +97,7 @@ void led_vu_init()
     led_strip_config.led_strip_working = heap_caps_malloc(strip.length * sizeof(struct led_color_t), MALLOC_CAP_8BIT);
     led_strip_config.led_strip_showing = heap_caps_malloc(strip.length * sizeof(struct led_color_t), MALLOC_CAP_8BIT);
     led_strip_config.gpio = strip.gpio;
-    led_strip_config.rmt_channel = rmt_system_base_channel++;
+    led_strip_config.rmt_channel = RMT_NEXT_TX_CHANNEL;
 
     // initialize driver 
     bool led_init_ok = led_strip_init(&led_strip_config);

--- a/components/led_strip/led_vu.c
+++ b/components/led_strip/led_vu.c
@@ -97,7 +97,7 @@ void led_vu_init()
     led_strip_config.led_strip_working = heap_caps_malloc(strip.length * sizeof(struct led_color_t), MALLOC_CAP_8BIT);
     led_strip_config.led_strip_showing = heap_caps_malloc(strip.length * sizeof(struct led_color_t), MALLOC_CAP_8BIT);
     led_strip_config.gpio = strip.gpio;
-    led_strip_config.rmt_channel = RMT_NEXT_TX_CHANNEL;
+    led_strip_config.rmt_channel = RMT_NEXT_TX_CHANNEL();
 
     // initialize driver 
     bool led_init_ok = led_strip_init(&led_strip_config);

--- a/components/services/globdefs.h
+++ b/components/services/globdefs.h
@@ -13,8 +13,8 @@
 #define I2C_SYSTEM_PORT		1
 #define SPI_SYSTEM_HOST		SPI2_HOST
 
-#define RMT_NEXT_TX_CHANNEL rmt_system_base_tx_channel++;
-#define RMT_NEXT_RX_CHANNEL rmt_system_base_rx_channel--;
+#define RMT_NEXT_TX_CHANNEL() rmt_system_base_tx_channel++;
+#define RMT_NEXT_RX_CHANNEL() rmt_system_base_rx_channel--;
 
 extern int i2c_system_port;
 extern int i2c_system_speed;

--- a/components/services/globdefs.h
+++ b/components/services/globdefs.h
@@ -13,11 +13,15 @@
 #define I2C_SYSTEM_PORT		1
 #define SPI_SYSTEM_HOST		SPI2_HOST
 
+#define RMT_NEXT_TX_CHANNEL rmt_system_base_tx_channel++;
+#define RMT_NEXT_RX_CHANNEL rmt_system_base_rx_channel--;
+
 extern int i2c_system_port;
 extern int i2c_system_speed;
 extern int spi_system_host;
 extern int spi_system_dc_gpio;
-extern int rmt_system_base_channel;
+extern int rmt_system_base_tx_channel;
+extern int rmt_system_base_rx_channel;
 typedef struct {
 	int timer, base_channel, max;
 } pwm_system_t;

--- a/components/services/infrared.c
+++ b/components/services/infrared.c
@@ -491,7 +491,7 @@ int8_t infrared_gpio(void) {
  * 
  */
 void infrared_init(RingbufHandle_t *rb, int gpio, infrared_mode_t mode) {  
-    int rmt_channel = rmt_system_base_channel++;
+    int rmt_channel = RMT_NEXT_RX_CHANNEL;
     rmt_config_t rmt_rx_config = RMT_DEFAULT_CONFIG_RX(gpio, rmt_channel);
     rmt_config(&rmt_rx_config);
     rmt_driver_install(rmt_rx_config.channel, 1000, 0);

--- a/components/services/infrared.c
+++ b/components/services/infrared.c
@@ -491,7 +491,7 @@ int8_t infrared_gpio(void) {
  * 
  */
 void infrared_init(RingbufHandle_t *rb, int gpio, infrared_mode_t mode) {  
-    int rmt_channel = RMT_NEXT_RX_CHANNEL;
+    int rmt_channel = RMT_NEXT_RX_CHANNEL();
     rmt_config_t rmt_rx_config = RMT_DEFAULT_CONFIG_RX(gpio, rmt_channel);
     rmt_config(&rmt_rx_config);
     rmt_driver_install(rmt_rx_config.channel, 1000, 0);

--- a/components/services/led.c
+++ b/components/services/led.c
@@ -241,7 +241,7 @@ bool led_config(int idx, gpio_num_t gpio, int color, int bright, led_type_t type
         for (const struct rmt_led_param_s *p = rmt_led_param; !leds[idx].rmt && p->type >= 0; p++) if (p->type == type) leds[idx].rmt = p;
         if (!leds[idx].rmt) return false;
 
-        if (led_rmt_channel < 0) led_rmt_channel = RMT_NEXT_TX_CHANNEL;
+        if (led_rmt_channel < 0) led_rmt_channel = RMT_NEXT_TX_CHANNEL();
         leds[idx].channel = led_rmt_channel;
 		leds[idx].bright = bright > 0 ? bright : 100;
 

--- a/components/services/led.c
+++ b/components/services/led.c
@@ -241,7 +241,7 @@ bool led_config(int idx, gpio_num_t gpio, int color, int bright, led_type_t type
         for (const struct rmt_led_param_s *p = rmt_led_param; !leds[idx].rmt && p->type >= 0; p++) if (p->type == type) leds[idx].rmt = p;
         if (!leds[idx].rmt) return false;
 
-        if (led_rmt_channel < 0) led_rmt_channel = rmt_system_base_channel++;
+        if (led_rmt_channel < 0) led_rmt_channel = RMT_NEXT_TX_CHANNEL;
         leds[idx].channel = led_rmt_channel;
 		leds[idx].bright = bright > 0 ? bright : 100;
 

--- a/components/services/services.c
+++ b/components/services/services.c
@@ -35,7 +35,8 @@ int i2c_system_port = I2C_SYSTEM_PORT;
 int i2c_system_speed = 400000;
 int spi_system_host = SPI_SYSTEM_HOST;
 int spi_system_dc_gpio = -1;
-int rmt_system_base_channel = RMT_CHANNEL_0;
+int rmt_system_base_tx_channel = RMT_CHANNEL_0;
+int rmt_system_base_rx_channel = RMT_CHANNEL_MAX-1;
 
 pwm_system_t pwm_system = {
 		.timer = LEDC_TIMER_0,

--- a/components/targets/muse/muse.c
+++ b/components/targets/muse/muse.c
@@ -95,7 +95,7 @@ void setup_rmt_data_buffer(struct led_state new_state);
 
 void ws2812_control_init(void)
 {
-  rmt_channel = rmt_system_base_channel++;  
+  rmt_channel = RMT_NEXT_TX_CHANNEL;  
   rmt_config_t config;
   config.rmt_mode = RMT_MODE_TX;
   config.channel = rmt_channel;

--- a/components/targets/muse/muse.c
+++ b/components/targets/muse/muse.c
@@ -95,7 +95,7 @@ void setup_rmt_data_buffer(struct led_state new_state);
 
 void ws2812_control_init(void)
 {
-  rmt_channel = RMT_NEXT_TX_CHANNEL;  
+  rmt_channel = RMT_NEXT_TX_CHANNEL();  
   rmt_config_t config;
   config.rmt_mode = RMT_MODE_TX;
   config.channel = rmt_channel;


### PR DESCRIPTION
Resolves issues with IR receiver on ESP32-S3 due to

_The first half (i.e. Channel 0 ~ 3) channels can only be configured for transmitting, and the other half (i.e. Channel 4 ~ 7) channels can only be configured for receiving._

This change has been tested on a standard ESP32 and should support C3 variations (although there are only 2 TX and 2 RX channels available).  