### PR TITLE
Add battery status to led_vu

### DIFF
--- a/components/led_strip/led_vu.c
+++ b/components/led_strip/led_vu.c
@@ -96,8 +96,8 @@ void led_vu_init()
         goto done;
     }
 
-	battery_handler_chain = battery_handler_svc;
-	battery_handler_svc = battery_svc;
+    battery_handler_chain = battery_handler_svc;
+    battery_handler_svc = battery_svc;
     battery_status = battery_level_svc();
    
     if (strip.length > LED_VU_MAX_LENGTH) strip.length = LED_VU_MAX_LENGTH;


### PR DESCRIPTION
Reserves a status led and improves layout of vu meter on smaller LED strips.

Battery status code based on the `muse.c` implementation. 