### PR TITLE
Fix SPI on ESP32S3

### DIFF
--- a/components/services/services.c
+++ b/components/services/services.c
@@ -380,7 +380,11 @@ void services_init(void) {
 	ESP_LOGI(TAG,"Configuring SPI mosi:%d miso:%d clk:%d host:%u dc:%d", spi_config->mosi_io_num, spi_config->miso_io_num, spi_config->sclk_io_num, spi_system_host, spi_system_dc_gpio);
 
 	if (spi_config->mosi_io_num != -1 && spi_config->sclk_io_num != -1) {
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4, 4, 0)
 		spi_bus_initialize( spi_system_host, spi_config, 1 );
+#else
+        spi_bus_initialize( spi_system_host, spi_config, SPI_DMA_CH_AUTO );
+#endif
 		if (spi_system_dc_gpio != -1) {
 			gpio_reset_pin(spi_system_dc_gpio);
 			gpio_set_direction( spi_system_dc_gpio, GPIO_MODE_OUTPUT );


### PR DESCRIPTION
Not exactly sure what is happening here,  but SPI does not initiate on any DMA setting except AUTO (3)  on my ESP32-S3 device with a built-in ST7789

AUTO works on my other  ST7789 display in both v4.4 and v4.3 ESP32 builds.  Obviously this is a limited test set!

**Should I PR like this (with compile options), add it as a configurable option, or just make the change for all?** 