### PR TITLE
Support for multiple command sets / alternate outputs

### DIFF
--- a/components/platform_console/cmd_config.c
+++ b/components/platform_console/cmd_config.c
@@ -143,6 +143,7 @@ static struct {
 } spdif_args;
 static struct {
     struct arg_str *jack_behavior;	
+	struct arg_str *output_set;
    	struct arg_int *loudness;
     struct arg_end *end;
 } audio_args;
@@ -451,7 +452,7 @@ static int do_audio_cmd(int argc, char **argv){
 		fclose(f);
 		return 1;
 	}
-    
+
     err = ESP_OK; // suppress any error code that might have happened in a previous step
 
 	if(audio_args.loudness->count>0){
@@ -478,10 +479,10 @@ static int do_audio_cmd(int argc, char **argv){
 
     if(audio_args.jack_behavior->count>0){
         err = ESP_OK; // suppress any error code that might have happened in a previous step
-        if(strcasecmp(audio_args.jack_behavior->sval[0],"Headphones")==0){
+        if(strcasecmp(audio_args.jack_behavior->sval[0],"Mute")==0){
             err = config_set_value(NVS_TYPE_STR, "jack_mutes_amp", "y");
         }
-        else if(strcasecmp(audio_args.jack_behavior->sval[0],"Subwoofer")==0){
+        else if(strcasecmp(audio_args.jack_behavior->sval[0],"Always On")==0){
             err = config_set_value(NVS_TYPE_STR, "jack_mutes_amp", "n");
         }
         else {
@@ -495,6 +496,27 @@ static int do_audio_cmd(int argc, char **argv){
         }
         else {
             fprintf(f,"Audio Jack Behavior changed to %s\n",audio_args.jack_behavior->sval[0]);
+        }        
+    }
+
+	if(audio_args.output_set->count>0){
+        err = ESP_OK; // suppress any error code that might have happened in a previous step
+        if(strcasecmp(audio_args.output_set->sval[0],"Off")==0){
+            err = config_set_value(NVS_TYPE_STR, "autoexec", "0");
+        }
+        else if(strcasecmp(audio_args.output_set->sval[0],"Alternative")==0){
+            err = config_set_value(NVS_TYPE_STR, "autoexec", "2");
+        }
+		else {
+            err = config_set_value(NVS_TYPE_STR, "autoexec", "1");
+        }
+
+        if(err!=ESP_OK){
+            nerrors++;
+            fprintf(f,"Error setting Output Set %s. %s\n",audio_args.output_set->sval[0], esp_err_to_name(err));
+        }
+        else {
+            fprintf(f,"Audio Output Set changed to %s\n",audio_args.output_set->sval[0]);
         }        
     }
 
@@ -964,11 +986,14 @@ cJSON * ledvu_cb(){
 cJSON * audio_cb(){
 	cJSON * values = cJSON_CreateObject();
 	char * 	p = config_alloc_get_default(NVS_TYPE_STR, "jack_mutes_amp", "n", 0);
-    cJSON_AddStringToObject(values,"jack_behavior",(strcmp(p,"1") == 0 ||strcasecmp(p,"y") == 0)?"Headphones":"Subwoofer");
-    FREE_AND_NULL(p);
+    cJSON_AddStringToObject(values,"jack_behavior",(strcmp(p,"1") == 0 ||strcasecmp(p,"y") == 0)?"Mute":"Always On");
+    free(p);
     p = config_alloc_get_default(NVS_TYPE_STR, "loudness", "0", 0);
     cJSON_AddStringToObject(values,"loudness",p);
-    FREE_AND_NULL(p);     
+    free(p);     
+	p = config_alloc_get_default(NVS_TYPE_STR, "autoexec", "1", 0);
+    cJSON_AddStringToObject(values,"output_set",(strcmp(p,"0") == 0)?"Off":((strcmp(p,"2") == 0)?"Alternative":"Default"));
+    FREE_AND_NULL(p);
 	return values;
 }
 cJSON * bt_source_cb(){
@@ -1042,6 +1067,7 @@ static int do_squeezelite_cmd(int argc, char **argv)
 
 cJSON * squeezelite_cb(){
 	cJSON * values = cJSON_CreateObject();
+    //TODO:  Should send data from active command (but response is currently issued directly by webpack on autoexec1 only) 
 	char * nvs_config= config_alloc_get(NVS_TYPE_STR, "autoexec1");
 	char **argv = NULL;
 	char *buf = NULL;
@@ -1395,8 +1421,9 @@ void register_ledvu_config(void){
 }
 
 void register_audio_config(void){
-	audio_args.jack_behavior = arg_str0("j", "jack_behavior","Headphones|Subwoofer","On supported DAC, determines the audio jack behavior. Selecting headphones will cause the external amp to be muted on insert, while selecting Subwoofer will keep the amp active all the time.");
+	audio_args.jack_behavior = arg_str0("j", "jack_behavior","Mute|Always On","On supported hardware, determines the audio jack behavior on the amplifier mute control.");
     audio_args.loudness = arg_int0("l", "loudness","0-10","Sets the loudness level, from 0 to 10. 0 will disable the loudness completely.");	
+    audio_args.output_set = arg_str0("o", "output_set","Off|Default|Alternative","Specified the Audio Output Mode. Use Off to disable Squeezelite.  Default for the standard autoexec set, and Alternative for set 2.");
     audio_args.end = arg_end(6);
     audio_args.end = arg_end(6);
 	const esp_console_cmd_t cmd = {

--- a/components/platform_console/platform_console.c
+++ b/components/platform_console/platform_console.c
@@ -202,7 +202,7 @@ int arg_parse_msg(int argc, char **argv, struct arg_hdr ** args){
 }
 void process_autoexec(){
 	int i=1;
-	char autoexec_name[21]={0};
+	char autoexec_name[24]={0};
 	char * autoexec_value=NULL;
 	uint8_t autoexec_flag=0;
 
@@ -216,9 +216,14 @@ void process_autoexec(){
 	if(str_flag !=NULL ){
 		autoexec_flag=atoi(str_flag);
 		ESP_LOGI(TAG,"autoexec is set to %s auto-process", autoexec_flag>0?"perform":"skip");
-		if(autoexec_flag == 1) {
+		if(autoexec_flag >= 1) {
 			do {
-				snprintf(autoexec_name,sizeof(autoexec_name)-1,"autoexec%u",i++);
+				if (autoexec_flag == 1) {
+					snprintf(autoexec_name,sizeof(autoexec_name)-1, "autoexec%u",i++);
+				}
+				else {
+					snprintf(autoexec_name,sizeof(autoexec_name)-1, "autoexec%u_%u",i++, autoexec_flag);
+				}
 				ESP_LOGD(TAG,"Getting command name %s", autoexec_name);
 				autoexec_value= config_alloc_get(NVS_TYPE_STR, autoexec_name);
 				if(autoexec_value!=NULL ){
@@ -389,8 +394,8 @@ void console_start() {
 	"\n");
 	if(!is_recovery_running){
 		printf("To automatically execute lines at startup:\n"
-				"\tSet NVS variable autoexec (U8) = 1 to enable, 0 to disable automatic execution.\n"
-				"\tSet NVS variable autoexec[1~9] (string)to a command that should be executed automatically\n");
+				"\tSet NVS variable autoexec (U8) = [1~N] to enable command sets, 0 to disable automatic execution.\n"
+				"\tSet NVS variable autoexec[1~9][_N] (string)to a command that should be executed automatically\n");
 	}
 	printf("\n\n");
 

--- a/components/squeezelite/output_i2s.c
+++ b/components/squeezelite/output_i2s.c
@@ -107,6 +107,7 @@ static uint32_t i2s_idle_since;
 static void (*pseudo_idle_chain)(uint32_t);
 static bool (*slimp_handler_chain)(u8_t *data, int len);
 static bool jack_mutes_amp;
+static bool sub_output_enabled;
 static bool running, isI2SStarted, ended;
 static i2s_config_t i2s_config;
 static u8_t *obuf;
@@ -142,8 +143,8 @@ static bool handler(u8_t *data, int len){
 	
 	if (!strncmp((char*) data, "audo", 4)) {
 		struct audo_packet *pkt = (struct audo_packet*) data;
-		// 0 = headphone (internal speakers off), 1 = sub out,
-		// 2 = always on (internal speakers on), 3 = always off	
+		// 0 = headphone (internal speakers off)/jack mutes amp/anaolgue, 1 = sub out/digital,
+		// 2 = always on (internal speakers on)/no mute/anaologue, 3 = always off	
 
 		if (jack_mutes_amp != (pkt->config == 0)) {
 			jack_mutes_amp = pkt->config == 0;
@@ -156,8 +157,15 @@ static bool handler(u8_t *data, int len){
 				adac->speaker(true);
 				if (amp_control.gpio != -1) gpio_set_level_x(amp_control.gpio, amp_control.active);
 			}	
-		}
 
+			if (sub_output_enabled != (pkt->config == 1) || sub_output_enabled == (pkt->config == 0)) {
+				sub_output_enabled = pkt->config == 1;
+				config_set_value(NVS_TYPE_STR, "autoexec", sub_output_enabled ? "2" : "1");		
+				
+				vTaskDelay(750 / portTICK_PERIOD_MS);
+				esp_restart();
+			}
+		}
 		LOG_INFO("got AUDO %02x", pkt->config);
 	} else {
 		res = false;
@@ -237,6 +245,10 @@ void output_init_i2s(log_level level, char *device, unsigned output_buf_size, ch
 	
 	p = config_alloc_get_default(NVS_TYPE_STR, "jack_mutes_amp", "n", 0);
 	jack_mutes_amp = (strcmp(p,"1") == 0 ||strcasecmp(p,"y") == 0);
+	free(p);
+
+	p = config_alloc_get_default(NVS_TYPE_STR, "autoexec", "1", 0);
+	sub_output_enabled = (strcmp(p,"2") == 0);
 	free(p);
 	
 #if BYTES_PER_FRAME == 8

--- a/plugin/SqueezeESP32/strings.txt
+++ b/plugin/SqueezeESP32/strings.txt
@@ -151,3 +151,20 @@ PLUGIN_SQUEEZEESP32_EQUALIZER
 PLUGIN_SQUEEZEESP32_EQUALIZER_SAVE
 	DE	Bitte speichern Sie die Equalizer Einstellungen, falls das Gerät diese dauerhaft verwenden soll. Ansonsten werden sie beim nächsten Start zurückgesetzt.
 	EN	Don't forget to save the Equalizer settings if you want them to stick. Otherwise they'll be reset next time you restart the device.
+
+
+ANALOGOUTMODE_SUBOUT
+	CS	Alternative
+	DA	Alternativ
+	DE	Alternative
+	EN	Alternative
+	ES	Alternativa
+	FI	Alternativ
+	FR	Alternative
+	HE	Alternative
+	IT	Alternativa
+	NL	Alternatief
+	NO	Alternativ
+	PL	Alternative
+	RU	Alternative
+	SV	Alternative


### PR DESCRIPTION
This PR is intended to provide the ability to remotely change the Line Out.  In my application, I wanted to switch between I2s DAC and SPDIF outputs, but you could use for BT as well.

It currently adds:
- `autoexec<x>_<set>` nvs options
- cleans up Audio options and 'audo' packet functionality*
- modifies "Subwoofer" to "Alternative" in the plugin (re. LMS web and "Line Out" menu control).

To Do:
- add 'Konfig" entries to allow targeted configurations
- (*)look at how to add direct amp control for "Always-Off" mode (to allow option to turn amp mute on/off regardless of jack input) 
- modify the webpack to update the active set, rather than hardcoded 'autoexec1' only. (@sle118  - is this something that you could help with or provide pointer?)
- add output status to lms response to keep LMS web accurate.

This is a draft, to see if this is of interest.   