### PR TITLE
UI optimization - migrate audio and display fixes

### DIFF
--- a/components/wifi-manager/webapp/src/index.ejs
+++ b/components/wifi-manager/webapp/src/index.ejs
@@ -44,18 +44,21 @@
 
 		</div>
 		<div class="info navbar-right" style="display: inline-flex;">
-			<span class="recovery_element material-icons " style="color:orange; display: none"
+			<span class="recovery_element material-icons" style="color:orange; display: none"
 				aria-label="🛑">system_update_alt</span>
 			<span id="battery" class="material-icons" style="fill:white; display: none"
 				aria-label="🔋">battery_full</span>
-			<span id="o_jack" class="material-icons" style="fill:white; display: none" aria-label="🎧">headphones</span>
-			<span id="s_airplay" class="material-icons" style="fill:white; display: none" aria-label="🍎">airplay</span>
-			<em id="s_cspot" class="fab fa-spotify" style="fill:white; display: inline"></em>
+			<span id="o_jack" class="material-icons" style="fill:white; display: none" 
+			    aria-label="🎧">headphones</span>
+			<span id="s_airplay" class="material-icons" style="fill:white; display: none" 
+			    aria-label="🍘">airplay</span>
 			<span data-bs-toggle="tooltip" id="o_type" data-bs-placement="top" title="">
-				<span id="o_bt" class="material-icons" style="fill:white; display: none" aria-label="">bluetooth</span>
+			  	<span id="o_bt" class="material-icons" style="fill:white; display: none" 
+				   aria-label="🔵">bluetooth</span>
 				<span id="o_spdif" class="material-icons" style="fill:white; display: none"
-					aria-label="">graphic_eq</span>
-				<span id="o_i2s" class="material-icons" style="fill:white; display: none" aria-label="🔈">speaker</span>
+				    aria-label="📻">spdif</span>
+				<span id="o_i2s" class="material-icons" style="fill:white; display: none"
+			         aria-label="🔈">speaker</span>
 			</span>
 			<span id="ethernet" class="material-icons if_eth" style="fill:white; display: none"
 				aria-label="ETH">cable</span>
@@ -94,15 +97,15 @@
 
 		<div id="myTabContent" class="tab-content">
 
-			<div class="tab-pane fade" id="tab-cfg-hw"> </div>
+			<div class="tab-pane fade" id="tab-cfg-hw"></div>
 			<div class="tab-pane fade" id="tab-cfg-syst"></div>
 			<div class="tab-pane fade" id="tab-cfg-gen"></div>
 			<div class="tab-pane fade" id="tab-cfg-fw">
 
-				<div class="card text-white  mb-3">
+				<div class="card mb-3">
 					<div class="card-header">Software Updates</div>
 					<div class="card-body">
-						<table class="table table-hover table-striped table-dark">
+						<table class="table table-hover table-striped table-primary">
 							<thead>
 								<tr>
 									<th class="border-bottom-0 pb-0" scope="col">Version</th>
@@ -145,7 +148,7 @@
 							</div>
 
 							<div class="col-auto">
-								<button id="btn_reboot_recovery" class="btn-warning ota_element"
+								<button id="btn_reboot_recovery" class="btn btn-warning ota_element"
 									type="submit">Recovery</button>
 							</div>
 						</div>
@@ -171,7 +174,7 @@
 						</div>
 					</div>
 				</div>
-				<div class="card text-white mb-3">
+				<div class="card mb-3">
 					<div class="card-header">Local Firmware Upload</div>
 					<div class="card-body">
 						<div id="uploaddiv" class="form-group row ">
@@ -194,7 +197,7 @@
 
 
 			<div class="tab-pane fade" id="tab-nvs">
-				<table class="table table-hover">
+				<table class="table table-hover table-secondary">
 					<thead>
 						<tr>
 							<th scope="col">Key</th>
@@ -215,147 +218,10 @@
 				</div>
 			</div>
 
-			<div class="tab-pane fade" id="tab-cfg-audio">
-				<div class="card text-white  mb-3">
-					<div class="card-header">Usage Templates</div>
-					<div class="card-body">
-							<fieldset class="form-group" id="output-tmpl">
-								<label>Output</label><br>
-								<div class="form-check form-check-inline">
-									<label class="form-check-label">
-										<input type="radio" class="form-check-input" name="output-tmpl" id="i2s">
-										I2S Dac
-									</label>
-								</div>
-								<div class="form-check form-check-inline">
-									<label class="form-check-label">
-										<input type="radio" class="form-check-input" name="output-tmpl" id="spdif">
-										SPDIF
-									</label>
-								</div>
-								<div class="form-check form-check-inline">
-									<label class="form-check-label">
-										<input type="radio" class="form-check-input" name="output-tmpl" id="bt">
-										Bluetooth
-									</label>
-								</div>
-							</fieldset>
-							<fieldset>
-							<div id="options">
-								<div class="form-group"><label for="cmd_opt_n">Set the player name</label><input
-										type="text" class="form-control sqcmd" placeholder="name" id="cmd_opt_n"></div>
-								<div class="form-group"><label for="cmd_opt_s">Server</label><input type="text"
-										class="form-control sqcmd" placeholder="server[:port]" id="cmd_opt_s"></div>
-								<div class="form-group"><label for="cmd_opt_b">Stream and Output buffer sizes (in
-										Kbytes)</label><input type="text" class="form-control sqcmd"
-										placeholder="stream:output" id="cmd_opt_b"></div>
-								<div class="form-group"><label for="cmd_opt_c">Restrict codecs </label><input
-										type="text" class="form-control sqcmd" placeholder="codec1,codec2"
-										id="cmd_opt_c"><small class="form-text text-muted">Supported: flac,pcm,mp3,ogg
-										(mad,mpg for specific mp3 codec)</small></div>
-								<div class="form-group"><label for="cmd_opt_C">Ouput device close timeout</label><input
-										type="text" class="form-control sqcmd" placeholder="timeout"
-										id="cmd_opt_C"><small class="form-text text-muted">Close output device after
-										timeout seconds, default
-										is to keep it open while player is 'on'</small></div>
-								<div class="form-group"><label for="cmd_opt_d">Set logging level</label><input
-										type="text" class="form-control sqcmd" placeholder="log=level"
-										id="cmd_opt_d"><small class="form-text text-muted">Logs:
-										all|slimproto|stream|decode|output, level:
-										info|debug|sdebug</small></div>
-								<div class="form-group"><label for="cmd_opt_e">Explicitly exclude native support of one
-										or more codecs</label><input type="text" class="form-control sqcmd"
-										placeholder="codec1,codec2" id="cmd_opt_e"><small
-										class="form-text text-muted">Supported: flac,pcm,mp3,ogg (mad,mpg for specific
-										mp3 codec)</small></div>
-								<div class="form-group"><label for="cmd_opt_m">Set mac address</label><input type="text"
-										class="form-control sqcmd" placeholder="mac addr" id="cmd_opt_m"><small
-										class="form-text text-muted">Format: ab:cd:ef:12:34:56</small></div>
-								<div class="form-group"><label for="cmd_opt_r">Sample rates supported, allows output to
-										be off when squeezelite is started</label><input type="text"
-										class="form-control sqcmd" placeholder="rates" id="cmd_opt_r"><small
-										class="form-text text-muted">&lt;maxrate&gt;|&lt;minrate&gt;&lt;maxrate&gt;&lt;rate1&gt;&lt;rate2&gt;&lt;rate3&gt;</small>
-								</div>
-
-								<div class="form-group hide" id="cmd_opt_R">
-									<label>Resample</label><br>
-									<div class="form-check form-check-inline">
-										<input class="form-check-input" type="radio" name="resample" id="resample_none"
-											suffix="" checked aint="false">
-										<label class="form-check-label" for="resampleNone">No resampling</label>
-									</div>
-									<div class="form-check form-check-inline">
-										<input class="form-check-input" type="radio" name="resample" id="resample"
-											suffix=' -R' aint="false">
-										<label class="form-check-label" for="resampleNone">Default</label>
-									</div>
-
-									<div class="form-check form-check-inline">
-										<input class="form-check-input" type="radio" name="resample" id="resample_b"
-											suffix=' -R -u b' aint="true">
-										<label class="form-check-label" for="resampleBasic">Basic linear
-											interpolation</label>
-									</div>
-									<div class="form-check form-check-inline">
-										<input class="form-check-input" type="radio" name="resample" id="resample_l"
-											suffix=' -R -u l' aint="true">
-										<label class="form-check-label" for="resample13Taps">13 taps</label>
-									</div>
-									<div class="form-check form-check-inline">
-										<input class="form-check-input" type="radio" name="resample" id="resample_m"
-											suffix=' -R -u m' aint="true">
-										<label class="form-check-label" for="resample21Taps">21 taps</label>
-									</div>
-									<div class="form-check form-check-inline">
-										<input class="form-check-input" type="checkbox" name="interpolate"
-											id="resample_i" suffix=":i">
-										<label class="form-check-label" for="interpolate">Interpolate filter
-											coefficients</label>
-									</div>
-								</div>
-
-								<div class="form-group"><label for="cmd_opt_Z">Report rate to server in helo as the
-										maximum sample rate we can support</label><input type="text"
-										class="form-control" placeholder="rate" id="cmd_opt_Z"></div>
-								<div class="form-group">
-									<div class="form-check">
-										<label class="form-check-label">
-											<input class="form-check-input" type="checkbox" id="cmd_opt_W" value=""
-												checked="">
-											Read wave and aiff format from header, ignore server parameters
-										</label>
-									</div>
-								</div>
-							</div>
-							<div class="form-group">
-
-								<div class="form-check">
-									<label class="form-check-label">
-										<input class="form-check-input" type="checkbox" id="disable-squeezelite" value="" >
-										Disable Squeezelite
-									</label>
-								</div>
-							</div>
-							<div style="margin-top: 16px;">
-								<div class="toast hide" role="alert" aria-live="assertive" aria-atomic="true"
-									id="toast_cfg-audio-tmpl">
-									<div class="toast-header"><strong class="mr-auto">Result</strong>
-										<button type="button" class="btn-close" data-bs-dismiss="toast"
-											aria-label="Close"></button>
-									</div>
-									<div class="toast-body" id="msg_cfg-audio-tmpl"></div>
-								</div>
-							</div>
-							<button id="save-autoexec1" type="submit" class="btn btn-info"
-								cmdname="cfg-audio-tmpl">Save</button>
-							<button id="commit-autoexec1" type="submit" class="btn btn-warning"
-								cmdname="cfg-audio-tmpl">Apply</button>
-						</fieldset>
-					</div>
-				</div>
-			</div>
+			<div class="tab-pane fade" id="tab-cfg-audio"></div>
+			
 			<div class="tab-pane fade active show" id="tab-wifi">
-				<div class="card text-white  mb-3">
+				<div class="card mb-3">
 					<div class="card-header">WiFi Status</div>
 
 					<div class="card-body if_eth" style="display: none">
@@ -363,7 +229,7 @@
 						<p>WiFi is inactive while connected to a wired network.
 					</div>
 					<div class="card-body if_wifi" style="display: none">
-						<table class="table table-hover">
+						<table class="table table-hover table-secondary">
 							<thead>
 								<tr>
 									<th scope="col">Joined</th>
@@ -473,7 +339,7 @@
 				<div class="card border-primary mb-3">
 					<div class="card-header">Logs</div>
 					<div class="card-body">
-						<table class="table table-hover">
+						<table class="table table-hover table-secondary">
 							<thead>
 								<tr>
 									<th scope="col">Timestamp</th>
@@ -491,7 +357,7 @@
 				<div class="card border-primary mb-3" id="pins" style="display: none;">
 					<div class="card-header">Pin Assignments</div>
 					<div class="card-body">
-						<table class="table table-hover">
+						<table class="table table-hover table-secondary">
 							<thead>
 								<tr>
 									<th scope="col">Device</th>
@@ -507,7 +373,7 @@
 				<div class="card border-primary mb-3" style="visibility: collapse;" id="tasks_sect">
 					<div class="card-header">Tasks</div>
 					<div class="card-body">
-						<table class="table table-hover">
+						<table class="table table-hover table-secondary">
 							<!-- console.log(msg_time.toLocaleString() + '\tname' + '\tcpu' + '\tstate' + '\tminstk' + '\tbprio' + '\tcprio' + '\tnum'); -->
 							<thead>
 								<tr>
@@ -527,7 +393,7 @@
 			</div>
 			<!-- syslog -->
 			<div class="tab-pane fade " id="tab-credits">
-				<div class="card text-white  mb-3">
+				<div class="card mb-3">
 					<div class="card-header">Credits</div>
 					<div class="card-body">
 						<p><strong><a
@@ -554,7 +420,7 @@
 						</ul>
 					</div>
 				</div>
-				<div class="card text-white  mb-3">
+				<div class="card mb-3">
 					<div class="card-header">Extras/Overrides</div>
 					<div class="card-body">
 						<fieldset>
@@ -578,9 +444,9 @@
 	</main>
 	<footer>
 		<div class="fixed-bottom d-flex justify-content-between  border-top border-dark p-3 bg-primary">
-			<span class="text-center" id="foot-fw"></span><button class="btn-warning ota_element " id="reboot_nav"
+			<span class="text-center" id="foot-fw"></span><button class="btn btn-warning ota_element " id="reboot_nav"
 				type="submit" style="display: none;">Reboot</button>
-			<button class="btn-warning recovery_element" id="reboot_ota_nav" type="submit" style="display: none;">Exit
+			<button class="btn btn-warning recovery_element" id="reboot_ota_nav" type="submit" style="display: none;">Exit
 				Recovery</button><span class="text-center" id="foot-if"></span>
 		</div>
 

--- a/components/wifi-manager/webapp/src/js/custom.js
+++ b/components/wifi-manager/webapp/src/js/custom.js
@@ -28,29 +28,7 @@ Object.assign(Date.prototype, {
     return this.toLocaleString(undefined, opt);
   },
 });
-function get_control_option_value(obj) {
-  let ctrl,id,val,opt;
-  let radio = false;
-  let checked = false;
-  if (typeof (obj) === 'string') {
-    id = obj;
-    ctrl = $(`#${id}`);
-  } else {
-    id = $(obj).attr('id');
-    ctrl = $(obj);
-  }
-  if(ctrl.attr('type') === 'checkbox'){
-    opt = $(obj).checked?id.replace('cmd_opt_', ''):'';
-    val = true;
-  }
-  else {
-    opt = id.replace('cmd_opt_', '');
-    val = $(obj).val();
-    val = `${val.includes(" ") ? '"' : ''}${val}${val.includes(" ") ? '"' : ''}`;
-  }
 
-  return { opt, val };
-}
 function handleNVSVisible() {
   let nvs_previous_checked = isEnabled(Cookies.get("show-nvs"));
   $('input#show-nvs')[0].checked = nvs_previous_checked;
@@ -59,18 +37,6 @@ function handleNVSVisible() {
   } else {
     $('*[href*="-nvs"]').hide();
   }
-}
-function concatenateOptions(options) {
-  let commandLine = ' ';
-  for (const [option, value] of Object.entries(options)) {
-    if (option !== 'n' && option !== 'o') {
-      commandLine += `-${option} `;
-      if (value !== true) {
-        commandLine += `${value} `;
-      }
-    }
-  }
-  return commandLine;
 }
 
 function isEnabled(val) {
@@ -288,8 +254,6 @@ let flashState = {
     return true === (this._state != this.UPLOADING && (this.statusText !== '' || this.statusPercent >= 0));
   },
 
-
-
   toString: function () {
     let keys = Object.keys(this);
     return keys.find(x => this[x] === this._state);
@@ -489,83 +453,6 @@ window.handleReboot = function (link) {
   }
 }
 
-function parseSqueezeliteCommandLine(commandLine) {
-  const options = {};
-  let output, name;
-  let otherValues = '';
-
-  const argRegex = /("[^"]+"|'[^']+'|\S+)/g;
-  const args = commandLine.match(argRegex);
-
-  let i = 0;
-
-  while (i < args.length) {
-    const arg = args[i];
-
-    if (arg.startsWith('-')) {
-      const option = arg.slice(1);
-
-      if (option === '') {
-        otherValues += args.slice(i).join(' ');
-        break;
-      }
-
-      let value = true;
-
-      if (i + 1 < args.length && !args[i + 1].startsWith('-')) {
-        value = args[i + 1].replace(/"/g, '').replace(/'/g, '');
-        i++;
-      }
-
-      options[option] = value;
-    } else {
-      otherValues += arg + ' ';
-    }
-
-    i++;
-  }
-
-  otherValues = otherValues.trim();
-  output = getOutput(options);
-  name = getName(options);
-  let otherOptions={btname:null,n:null};
-  // assign o and n options to otheroptions if present
-  if (options.o && output.toUpperCase() === 'BT') {
-    let temp = parseSqueezeliteCommandLine(options.o);
-    if(temp.name) {
-      otherOptions.btname = temp.name;
-    }
-    delete options.o;
-  }
-  if (options.n) {
-    otherOptions['n'] = options.n;
-    delete options.n;
-  }
-  return { name, output, options, otherValues,otherOptions };  
-}
-
-function getOutput(options) {
-  let output;
-  if (options.o){
-    output = options.o.replace(/"/g, '').replace(/'/g, '');
-    /* set output as the first alphanumerical word in the command line */
-    if (output.indexOf(' ') > 0) {
-      output = output.substring(0, output.indexOf(' '));
-    }
-  }
-  return output;
-}
-
-function getName(options) {
-  let name;
-  /* if n option present, assign to name variable */
-  if (options.n){
-    name = options.n.replace(/"/g, '').replace(/'/g, '');
-  }
-  return name;
-}
-
-
 function isConnected() {
   return ConnectedTo.hasOwnProperty('ip') && ConnectedTo.ip != '0.0.0.0' && ConnectedTo.ip != '';
 }
@@ -588,27 +475,6 @@ function handlebtstate(data) {
 
   $('#o_type').attr('title', tt);
   $('#o_bt').html(isConnected() ? icon.label : icon.text);
-}
-function handleTemplateTypeRadio(outtype) {
-  $('#o_type').children('span').css({ display: 'none' });
-  let changed = false;
-  if (outtype === 'bt') {
-    changed = output !== 'bt' && output !== '';
-    output = 'bt';
-  } else if (outtype === 'spdif') {
-    changed = output !== 'spdif' && output !== '';
-    output = 'spdif';
-  } else {
-    changed = output !== 'i2s' && output !== '';
-    output = 'i2s';
-  }
-  $('#' + output).prop('checked', true);
-  $('#o_' + output).css({ display: 'inline' });
-  if (changed) {
-    Object.keys(commandDefaults[output]).forEach(function (key) {
-      $(`#cmd_opt_${key}`).val(commandDefaults[output][key]);
-    });
-  }
 }
 
 function handleExceptionResponse(xhr, _ajaxOptions, thrownError) {
@@ -657,15 +523,6 @@ let releaseURL =
 let recovery = false;
 let messagesHeld = false;
 let commandBTSinkName = '';
-const commandHeader = 'squeezelite ';
-const commandDefaults = {
-  i2s: { b: "500:2000", C: "30", W: "", Z: "96000", o: "I2S" },
-  spdif: { b: "500:2000", C: "30", W: "", Z: "48000", o: "SPDIF" },
-  bt: { b: "500:2000", C: "30", W: "", Z: "44100", o: "BT" },
-};
-let validOptions = {
-  codecs: ['flac', 'pcm', 'mp3', 'ogg', 'aac', 'wma', 'alac', 'dsd', 'mad', 'mpg']
-};
 
 //let blockFlashButton = false;
 let apList = null;
@@ -675,7 +532,6 @@ let messagecount = 0;
 let messageseverity = 'MESSAGING_INFO';
 let SystemConfig = {};
 let LastCommandsState = null;
-var output = '';
 let hostName = '';
 let versionName = 'Squeezelite-ESP32';
 let prevmessage = '';
@@ -887,84 +743,7 @@ function delayReboot(duration, cmdname, ota = 'reboot') {
       });
     });
 }
-// eslint-disable-next-line no-unused-vars
-window.saveAutoexec1 = function (apply) {
-  showCmdMessage('cfg-audio-tmpl', 'MESSAGING_INFO', 'Saving.\n', false);
-  let commandLine = `${commandHeader} -o ${output} `;
-  $('.sqcmd').each(function () {
-    let { opt, val } = get_control_option_value($(this));
-    if ((opt && opt.length>0 ) && typeof(val) == 'boolean' || val.length > 0) {
-      const optStr=opt===':'?opt:(` -${opt} `);
-      val = typeof(val) == 'boolean'?'':val;
-      commandLine += `${optStr} ${val}`;
-    }
-  });
-  const resample=$('#cmd_opt_R input[name=resample]:checked');
-  if (resample.length>0 && resample.attr('suffix')!=='') {
-    commandLine += resample.attr('suffix');
-    // now check resample_i option and if checked, add suffix to command line
-    if ($('#resample_i').is(":checked") && resample.attr('aint') =='true')  {
-          commandLine += $('#resample_i').attr('suffix');
-    }
-}
 
-    
-  if (output === 'bt') {
-    showCmdMessage(
-      'cfg-audio-tmpl',
-      'MESSAGING_INFO',
-      'Remember to configure the Bluetooth audio device name.\n',
-      true
-    );
-  }
-  commandLine += concatenateOptions(options);
-  const data = {
-    timestamp: Date.now(),
-  };
-  data.config = {
-    autoexec1: { value: commandLine, type: 33 },
-    // autoexec: {
-    //   value: $('#disable-squeezelite').prop('checked') ? '0' : '1',
-    //   type: 33,
-    // },
-  };
-
-  $.ajax({
-    url: '/config.json',
-    dataType: 'text',
-    method: 'POST',
-    cache: false,
-    contentType: 'application/json; charset=utf-8',
-    data: JSON.stringify(data),
-    error: handleExceptionResponse,
-    complete: function (response) {
-      if (
-        response.responseText &&
-        JSON.parse(response.responseText).result === 'OK'
-      ) {
-        showCmdMessage('cfg-audio-tmpl', 'MESSAGING_INFO', 'Done.\n', true);
-        if (apply) {
-          delayReboot(1500, 'cfg-audio-tmpl');
-        }
-      } else if (JSON.parse(response.responseText).result) {
-        showCmdMessage(
-          'cfg-audio-tmpl',
-          'MESSAGING_WARNING',
-          JSON.parse(response.responseText).Result + '\n',
-          true
-        );
-      } else {
-        showCmdMessage(
-          'cfg-audio-tmpl',
-          'MESSAGING_ERROR',
-          response.statusText + '\n'
-        );
-      }
-      console.log(response.responseText);
-    },
-  });
-  console.log('sent data:', JSON.stringify(data));
-}
 window.handleDisconnect = function () {
   $.ajax({
     url: '/connect.json',
@@ -1008,30 +787,6 @@ window.handleConnect = function () {
   // now we can re-set the intervals regardless of result
 
 }
-function renderError(opt,error){
-  const fieldname = `cmd_opt_${opt}`;
-  let errorFieldName=`${fieldname}-error`;
-  let errorField=$(`#${errorFieldName}`);
-  let field=$(`#${fieldname}`);
-  
-  if (!errorField || errorField.length ==0) {
-    field.after(`<div id="${errorFieldName}" class="invalid-feedback"></div>`);
-    errorField=$(`#${errorFieldName}`);
-  }
-  if(error.length ==0){
-      errorField.hide();
-      field.removeClass('is-invalid');
-      field.addClass('is-valid');
-      errorField.text('');
-  }
-  else {     
-      errorField.show();
-      errorField.text(error);
-      field.removeClass('is-valid');
-      field.addClass('is-invalid');
-  }
-  return errorField;
-}
 $(document).ready(function () {
   $('.material-icons').each(function (_index, entry) {
     entry.attributes['icon'] = entry.textContent;
@@ -1060,43 +815,6 @@ $(document).ready(function () {
 
   });
   setTimeout(refreshAP, 1500);
-  /* add validation for cmd_opt_c, which accepts a comma separated list. 
-    getting known codecs from validOptions.codecs array
-    use bootstrap classes to highlight the error with an overlay message */
-  $('#options input').on('input', function () {
-    const { opt, val } = get_control_option_value(this);
-    if (opt === 'c' || opt === 'e') {
-      const fieldname = `cmd_opt_${opt}_codec-error`;
-      
-      const values = val.split(',').map(function (item) {
-        return item.trim();
-      });
-      /* get a list of invalid codecs */
-      const invalid = values.filter(function (item) {
-        return !validOptions.codecs.includes(item);
-      });
-      renderError(opt,invalid.length > 0 ? `Invalid codec(s) ${invalid.join(', ')}` : '');
-    }
-    /* add validation for cmd_opt_m, which accepts a mac_address */
-    if (opt === 'm') {
-      const mac_regex = /^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$/;
-      renderError(opt,mac_regex.test(val) ? '' : 'Invalid MAC address');
-    }
-    if (opt === 'r') {
-        const rateRegex =  /^(\d+\.?\d*|\.\d+)-(\d+\.?\d*|\.\d+)$|^(\d+\.?\d*)$|^(\d+\.?\d*,)+\d+\.?\d*$/;
-        renderError(opt,rateRegex.test(val)?'':`Invalid rate(s) ${val}. Acceptable format: <maxrate>|<minrate>-<maxrate>|<rate1>,<rate2>,<rate3>`);
-    }
-
-
-
-  }
-
-
-  );
-
-
-
-
 
   $('#WifiConnectDialog')[0].addEventListener('shown.bs.modal', function (event) {
     $("*[class*='connecting']").hide();
@@ -1118,7 +836,6 @@ $(document).ready(function () {
         }
       }
     }
-
 
     if (ConnectingToSSID.Action !== ConnectingToActions.STS) {
       $('.connecting-init').show();
@@ -1216,28 +933,7 @@ $(document).ready(function () {
     }
   });
 
-  $('#disable-squeezelite').on('click', function () {
-    // this.checked = this.checked ? 1 : 0;
-    // $('#disable-squeezelite').prop('checked')
-    if (this.checked) {
-      // Store the current value before overwriting it
-      const currentValue = $('#cmd_opt_s').val();
-      $('#cmd_opt_s').data('originalValue', currentValue);
-    
-      // Overwrite the value with '-disable'
-      $('#cmd_opt_s').val('-disable');
-    } else {
-      // Retrieve the original value
-      const originalValue = $('#cmd_opt_s').data('originalValue');
-    
-      // Restore the original value if it exists, otherwise set it to an empty string
-      $('#cmd_opt_s').val(originalValue ? originalValue : '');
-    }
-    
-  });
-
   
-
   $('input#show-nvs').on('click', function () {
     this.checked = this.checked ? 1 : 0;
     Cookies.set("show-nvs", this.checked ? 'Y' : 'N');
@@ -1251,12 +947,6 @@ $(document).ready(function () {
   });
   $('#btn_flash').on('click', function () {
     hFlash();
-  });
-  $('#save-autoexec1').on('click', function () {
-    saveAutoexec1(false);
-  });
-  $('#commit-autoexec1').on('click', function () {
-    saveAutoexec1(true);
   });
   $('#btn_disconnect').on('click', function () {
     ConnectedTo = {};
@@ -1312,9 +1002,6 @@ $(document).ready(function () {
       flashState.StartOTA();
     }
 
-  });
-  $('[name=output-tmpl]').on('click', function () {
-    handleTemplateTypeRadio(this.id);
   });
 
   $('#chkUpdates').on('click', function () {
@@ -1510,7 +1197,6 @@ window.setURL = function (button) {
 
   $('#fwurl').val(url);
 }
-
 
 function rssiToIcon(rssi) {
   if (rssi >= -55) {
@@ -1881,7 +1567,6 @@ function handleNetworkStatus(data) {
 }
 
 
-
 function batteryToIcon(voltage) {
   /* Assuming Li-ion 18650s as a power source, 3.9V per cell, or above is treated
   as full charge (>75% of capacity).  3.4V is empty. The gauge is loosely
@@ -2004,7 +1689,6 @@ window.runCommand = function (button, reboot) {
   if (cmdstring === 'cfg-hw-preset') return handleHWPreset(allfields, reboot);
   cmdstring += ' ';
   if (fields) {
-
     for (const field of allfields) {
       let qts = '';
       let opt = '';
@@ -2097,7 +1781,7 @@ function getCommands() {
         const isConfig = cmdParts[0] === 'cfg';
         const targetDiv = '#tab-' + cmdParts[0] + '-' + cmdParts[1];
         let innerhtml = '';
-        innerhtml += `<div class="card text-white mb-3"><div class="card-header">${command.help.encodeHTML().replace(/\n/g, '<br />')}</div><div class="card-body"><fieldset id="flds-${command.name}">`;
+        innerhtml += `<div class="card mb-3"><div class="card-header">${command.help.encodeHTML().replace(/\n/g, '<br />')}</div><div class="card-body"><fieldset id="flds-${command.name}">`;
         if (command.argtable) {
           command.argtable.forEach(function (arg) {
             let placeholder = arg.datatype || '';
@@ -2109,20 +1793,18 @@ function getCommands() {
             attributes += 'shortopts="' + arg.shortopts + '" ';
             attributes += 'checkbox=' + arg.checkbox + ' ';
             attributes += 'cmdname="' + command.name + '" ';
-            attributes +=
-              'id="' +
-              ctrlname +
-              '" name="' +
-              ctrlname +
-              '" hasvalue="' +
-              arg.hasvalue +
-              '"   ';
-            let extraclass = arg.mincount > 0 ? 'bg-success' : '';
+            attributes += 'id="' + ctrlname + '" name="' + ctrlname + '" ';
+            if (arg.longopts && arg.longopts.startsWith('_')){
+              attributes += "readonly ";
+            }
+            let extraclass = arg.mincount > 0 ? 'is-invalid' : '';
             if (arg.glossary === 'hidden') {
               attributes += ' style="visibility: hidden;"';
             }
             if (arg.checkbox) {
-              innerhtml += `<div class="form-check"><label class="form-check-label"><input type="checkbox" ${attributes} class="form-check-input ${extraclass}" value="" >${arg.glossary.encodeHTML()}</label>`;
+              innerhtml += `<div class="form-check"><label class="form-check-label"><input type="checkbox" ${attributes} class="form-check-input ${extraclass}" value="" >${arg.glossary.encodeHTML()}</label></div><div>`;
+            } else if (arg.remark) {
+              innerhtml += `<div class="form-group"><label>${arg.glossary.encodeHTML()}</label>`;
             } else {
               innerhtml += `<div class="form-group" ><label for="${ctrlname}">${arg.glossary.encodeHTML()}</label>`;
               if (placeholder.includes('|')) {
@@ -2142,7 +1824,10 @@ function getCommands() {
               }
             }
 
-            innerhtml += `${arg.checkbox ? '</div>' : ''}<small class="form-text text-muted">Previous value: ${arg.checkbox ? (curvalue ? 'Checked' : 'Unchecked') : (curvalue || '')}</small>${arg.checkbox ? '' : '</div>'}`;
+            if (!arg.remark) {
+              innerhtml += `<small class="form-text text-muted">Previous value: ${arg.checkbox ? (curvalue ? 'Checked' : 'Unchecked') : (curvalue || '')}</small>`;
+            }
+            innerhtml += `</div>`;
           });
         }
         innerhtml += `<div style="margin-top: 16px;">
@@ -2179,11 +1864,15 @@ function getCommands() {
           const ctrlValue = getLongOps(data, command.name, arg.longopts);
           if (arg.checkbox) {
             $(ctrlselector)[0].checked = ctrlValue;
-          } else {
+          } else if (!arg.remark) {
             if (ctrlValue !== undefined) {
               $(ctrlselector)
                 .val(ctrlValue)
                 .trigger('change');
+                if (arg.mincount && arg.mincount > 0) {
+                  $(ctrlselector).removeClass('is-invalid');
+                  $(ctrlselector).addClass('is-valid');
+                }
             }
             if (
               $(ctrlselector)[0].value.length === 0 &&
@@ -2221,10 +1910,7 @@ function getConfig() {
       .sort()
       .forEach(function (key) {
         let val = data[key].value;
-       if (key === 'autoexec1') {
-          /* call new function to parse the squeezelite options */
-          processSqueezeliteCommandLine(val);
-        } else if (key === 'host_name') {
+        if (key === 'host_name') {
           val = val.replaceAll('"', '');
           $('input#dhcp-name1').val(val);
           $('input#dhcp-name2').val(val);
@@ -2266,7 +1952,6 @@ function getConfig() {
         $('input#' + key).val(data[key].value);
       });
     if(commandBTSinkName.length > 0) {
-      // persist the sink name found in the autoexec1 command line
       $('#cfg-audio-bt_source-sink_name').val(commandBTSinkName);
     }
     $('tbody#nvsTable').append(
@@ -2297,51 +1982,6 @@ function getConfig() {
   }).fail(function (xhr, ajaxOptions, thrownError) {
     handleExceptionResponse(xhr, ajaxOptions, thrownError);
   });
-}
-
-function processSqueezeliteCommandLine(val) {
-  const parsed = parseSqueezeliteCommandLine(val);
-  if (parsed.output.toUpperCase().startsWith('I2S')) {
-    handleTemplateTypeRadio('i2s');
-  } else if (parsed.output.toUpperCase().startsWith('SPDIF')) {
-    handleTemplateTypeRadio('spdif');
-  } else if (parsed.output.toUpperCase().startsWith('BT')) {
-    if(parsed.otherOptions.btname){ 
-      commandBTSinkName= parsed.otherOptions.btname;
-    }
-    handleTemplateTypeRadio('bt');
-
-  }
-  Object.keys(parsed.options).forEach(function (key) {
-    const option = parsed.options[key];
-    if (!$(`#cmd_opt_${key}`).hasOwnProperty('checked')) {
-      $(`#cmd_opt_${key}`).val(option);
-    } else {
-      $(`#cmd_opt_${key}`)[0].checked = option;
-    }
-  });
-  if (parsed.options.hasOwnProperty('u')) {
-    // parse -u v[:i] and check the appropriate radio button with id #resample_v
-    const [resampleValue, resampleInterpolation] = parsed.options.u.split(':');
-    $(`#resample_${resampleValue}`).prop('checked', true);
-    // if resampleinterpolation is set, check  resample_i checkbox
-    if (resampleInterpolation) {
-      $('#resample_i').prop('checked', true);
-    }
-  }
-  if (parsed.options.hasOwnProperty('s')) {
-    // parse -u v[:i] and check the appropriate radio button with id #resample_v
-    if(parsed.options.s === '-disable'){
-      $('#disable-squeezelite')[0].checked = true;
-    }
-    else {
-      $('#disable-squeezelite')[0].checked = false;
-    }
-  }
-
-  
-
-
 }
 
 function showLocalMessage(message, severity) {


### PR DESCRIPTION
This PR is aimed at freeing up and fixing some minor display issues by
- Removing audio setup from webapp (allows easier customization in standard builds)
- fixes some button displays
- some minor formatting changes to address latest bootswatch issues and makes re-skinning simpler

| Partition | Current with UI | Current w/o UI | This PR with UI | This PR w/o UI |
| --------- | --------- | --------- | --------- | --------- |
| recovery.bin | 1319584 | 1295856 | 1296432 | 1269680 |
| squeezlelite.bin | 2666048 | 2640768 | 2647584 | 2614576 |

This is the first in a series of potential improvements.  The next offers gains by moving more UI options to OTA only.  It saves significant space in both the 'with and 'w/o' CONFIG_UI. (EDIT: I'm at 1263520 | 2642896 with full UI in OTA mode)

P.S.  You will need to rebuild the webapp
