### PR TITLE
misc changes (see PR)

### DIFF
--- a/components/metrics/Batch.cpp
+++ b/components/metrics/Batch.cpp
@@ -77,7 +77,7 @@ void Batch::push() {
 
     char* json_str = to_json_str();
     ESP_LOGV(TAG, "Metrics payload: %s", json_str);
-    time_t start_time = millis();
+    uint32_t start_time = gettime_ms();
 
     status_code = metrics_http_post_request(json_str, _url);
 
@@ -85,7 +85,7 @@ void Batch::push() {
         _events.clear();
     }
     FREE_AND_NULL(json_str)
-    ESP_LOGD(TAG, "Total duration for metrics call: %lu. ", millis() - start_time);
+    ESP_LOGD(TAG, "Total duration for metrics call: %lu. ", gettime_ms() - start_time);
 }
 
 void Batch::build_guid() {

--- a/components/metrics/Events.h
+++ b/components/metrics/Events.h
@@ -45,7 +45,7 @@ class Event {
     }
   private:
     char* _name = nullptr;
-    time_t _time;
+    uint32_t _time;
     cJSON* _json = nullptr;    
 };
 

--- a/components/metrics/Metrics.cpp
+++ b/components/metrics/Metrics.cpp
@@ -31,7 +31,7 @@ extern bool is_network_connected();
 #define MAX_HTTP_RECV_BUFFER 512
 
 static bool metrics_usage_gen = false;
-static time_t metrics_usage_gen_time = 0;
+static uint32_t metrics_usage_gen_time = 0;
 #ifndef METRICS_API_KEY
     #pragma message "Metrics API key needs to be passed from the environment"
     #define METRICS_API_KEY "ZZZ"
@@ -56,7 +56,7 @@ static void metrics_timer_cb(void* timer_id) {
             batch.push();
         }
     }
-    if (millis() > metrics_usage_gen_time && !metrics_usage_gen) {
+    if (gettime_ms() > metrics_usage_gen_time && !metrics_usage_gen) {
         metrics_usage_gen = true;
         ESP_LOGV(TAG, "Generate command list to pull features");
         cJSON* cmdlist = get_cmd_list();
@@ -75,7 +75,7 @@ void metrics_init() {
     }
     // set a 20 seconds delay before generating the
     // features so the system has time to boot
-    metrics_usage_gen_time = millis() + 20000;
+    metrics_usage_gen_time = gettime_ms() + 20000;
 }
 
 void metrics_event_playback(const char* source) {

--- a/components/platform_config/platform_config.c
+++ b/components/platform_config/platform_config.c
@@ -538,7 +538,7 @@ bool config_set_group_bit(int bit_num,bool flag){
 	return result;
 }
 
-void config_set_default(nvs_type_t type, const char *key, void * default_value, size_t blob_size) {
+void config_set_default(nvs_type_t type, const char *key, const void * default_value, size_t blob_size) {
 	if(!config_lock(LOCK_MAX_WAIT/portTICK_PERIOD_MS)){
 		ESP_LOGE(TAG, "Unable to lock config");
 		return;

--- a/components/platform_config/platform_config.c
+++ b/components/platform_config/platform_config.c
@@ -791,43 +791,6 @@ cJSON* cjson_update_number(cJSON** root, const char* key, int value) {
 	}
     return *root;
 }
-bool config_parse_param_int(const char * config,const char * param, char delimiter,int * value){
-	const char *p;
-	if(!value){
-		return false;
-	}	
-	if ((p = strcasestr(config, param)) && (p = strchr(p, delimiter))) {
-		*value = atoi(p+1);
-		return true;
-	}
-	return false;
-}
-bool config_parse_param_float(const char * config,const char * param, char delimiter,double * value){
-	const  char *p;
-	if(!value){
-		return false;
-	}	
-	if ((p = strcasestr(config, param)) && (p = strchr(p, delimiter))) {
-		*value = atof(p+1);
-		return true;
-	}
-	return false;
-}
-bool config_parse_param_str(const char *source, const char *param, char delimiter, char *value, size_t value_size) {
-    char *p;
-    if ((p = strstr(source, param)) && (p = strchr(p, delimiter))) {
-        while (*++p == ' ');  // Skip spaces
-        // Read the value into the buffer, making sure not to overflow
-        snprintf(value, value_size, "%s", p);
-        char *end = strchr(value, ',');
-        if (end) {
-            *end = '\0';  // Null-terminate at the comma, if found
-        }
-        return true;
-    }
-    return false;
-}
-												
 
 IMPLEMENT_SET_DEFAULT(uint8_t,NVS_TYPE_U8);
 IMPLEMENT_SET_DEFAULT(int8_t,NVS_TYPE_I8);

--- a/components/platform_config/platform_config.h
+++ b/components/platform_config/platform_config.h
@@ -65,7 +65,7 @@ esp_err_t config_set_cjson_str_and_free(const char *key, cJSON *value);
 esp_err_t config_set_cjson(const char *key, cJSON *value, bool free_cjson);
 void config_get_uint16t_from_str(const char *key, uint16_t *value, uint16_t default_value);
 void config_delete_key(const char *key);
-void config_set_default(nvs_type_t type, const char *key, void * default_value, size_t blob_size);
+void config_set_default(nvs_type_t type, const char *key, const void * default_value, size_t blob_size);
 void * config_alloc_get(nvs_type_t nvs_type, const char *key) ;
 bool wait_for_commit();
 char * config_alloc_get_json(bool bFormatted);

--- a/components/platform_config/platform_config.h
+++ b/components/platform_config/platform_config.h
@@ -9,11 +9,6 @@
 extern "C" {
 #endif
 
-#ifdef PARSE_WITH_FUNC
-#define PARSE_PARAM(S,P,C,V) config_parse_param_int(S,P,C,(int*)&V)
-#define PARSE_PARAM_STR(S,P,C,V,I) config_parse_param_str(S,P,C,V,I)
-#define PARSE_PARAM_FLOAT(S,P,C,V) config_parse_param_float(S,P,C,&V)
-#else
 #define PARSE_PARAM(S,P,C,V)   do {		                      	    			\
  	char *__p;																	\
  	if ((__p = strcasestr(S, P)) && (__p = strchr(__p, C))) V = atoi(__p+1); 	\
@@ -31,7 +26,7 @@ extern "C" {
  		sscanf(__p,"%" #I "[^,]", V);					                        \
  	}   												                        \
  } while (0)
-#endif
+
 #define DECLARE_SET_DEFAULT(t) void config_set_default_## t (const char *key, t  value);
 #define DECLARE_GET_NUM(t) esp_err_t config_get_## t (const char *key, t *  value);
 #ifndef FREE_RESET
@@ -55,9 +50,6 @@ bool config_has_changes();
 void config_commit_to_nvs();
 void config_start_timer();
 void config_init();
-bool config_parse_param_int(const char * config,const char * param,  char  delimiter,int * value);
-bool config_parse_param_float(const char * config,const char * param,  char  delimiter,double * value);
-bool config_parse_param_str(const char *source, const char *param, char delimiter, char *value, size_t value_size);
 void * config_alloc_get_default(nvs_type_t type, const char *key, void * default_value, size_t blob_size);
 void * config_alloc_get_str(const char *key, char *lead, char *fallback);
 cJSON * config_alloc_get_cjson(const char *key);

--- a/components/platform_console/cmd_system.c
+++ b/components/platform_console/cmd_system.c
@@ -67,8 +67,10 @@ static void register_heap();
 static void register_dump_heap();
 static void register_version();
 static void register_restart();
+#if CONFIG_WITH_CONFIG_UI
 static void register_deep_sleep();
 static void register_light_sleep();
+#endif
 static void register_factory_boot();
 static void register_restart_ota();
 static void register_set_services();
@@ -556,6 +558,7 @@ static void register_tasks()
 
 /** 'deep_sleep' command puts the chip into deep sleep mode */
 
+#if CONFIG_WITH_CONFIG_UI
 static struct {
     struct arg_int *wakeup_time;
     struct arg_int *wakeup_gpio_num;
@@ -619,6 +622,8 @@ static void register_deep_sleep()
     };
     ESP_ERROR_CHECK( esp_console_cmd_register(&cmd) );
 }
+#endif
+
 static int enable_disable(FILE * f,char * nvs_name, struct arg_lit *arg){
 	esp_err_t err = config_set_value(NVS_TYPE_STR, nvs_name, arg->count>0?"Y":"N");
 	const char * name = arg->hdr.longopts?arg->hdr.longopts:arg->hdr.glossary;
@@ -737,6 +742,8 @@ static void register_set_services(){
 	cmd_to_json_with_cb(&cmd,&set_services_cb);
     ESP_ERROR_CHECK( esp_console_cmd_register(&cmd) );
 }
+
+#if CONFIG_WITH_CONFIG_UI
 static struct {
     struct arg_int *wakeup_time;
     struct arg_int *wakeup_gpio_num;
@@ -828,4 +835,4 @@ static void register_light_sleep()
     };
     ESP_ERROR_CHECK( esp_console_cmd_register(&cmd) );
 }
-
+#endif

--- a/components/tools/tools.c
+++ b/components/tools/tools.c
@@ -11,8 +11,6 @@
 #include <stdint.h>
 #include <string.h>
 #include <ctype.h>
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
 #include "esp_task.h"
 #include "esp_tls.h"
 #include "esp_http_client.h"
@@ -24,7 +22,6 @@
 #error CONFIG_FREERTOS_THREAD_LOCAL_STORAGE_POINTERS must be at least 2
 #endif
 
-#include "cJSON.h"
 const static char TAG[] = "tools";
 
 /****************************************************************************************
@@ -326,13 +323,6 @@ static esp_err_t http_event_handler(esp_http_client_event_t *evt) {
 	}
 
 	return ESP_OK;
-}
-
- 
-time_t millis() {
-    struct timeval tv;
-    gettimeofday(&tv, NULL);
-    return (tv.tv_sec * 1000) + (tv.tv_usec / 1000);
 }
 
 void dump_json_content(const char* prefix, cJSON* json, int level) {

--- a/components/tools/tools.h
+++ b/components/tools/tools.h
@@ -9,10 +9,9 @@
  */
  
 #pragma once
-#include "cJSON.h"
-#include "time.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+#include "cJSON.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -56,6 +55,13 @@ void* 		clone_obj_psram(void * source, size_t source_sz);
 char* 		strdup_psram(const char * source);
 const char* str_or_unknown(const char * str);
 const char* str_or_null(const char * str);
+void        dump_json_content(const char* prefix, cJSON* json, int level);
+
+#ifndef gettime_ms
+// body is provided somewhere else...
+uint32_t _gettime_ms_(void);
+#define gettime_ms _gettime_ms_
+#endif
 
 typedef void (*http_download_cb_t)(uint8_t* data, size_t len, void *context);
 void		http_download(char *url, size_t max, http_download_cb_t callback, void *context);
@@ -73,9 +79,6 @@ BaseType_t xTaskCreateEXTRAM( TaskFunction_t pvTaskCode,
 void vTaskDeleteEXTRAM(TaskHandle_t xTask);                            
 
 extern const char unknown_string_placeholder[];
-
-time_t millis();
-void dump_json_content(const char* prefix, cJSON* json, int level);
 
 #ifdef __cplusplus
 }

--- a/main/esp_app_main.c
+++ b/main/esp_app_main.c
@@ -233,8 +233,8 @@ void register_default_string_val(const char * key, const char * value){
 	char * existing =(char *)config_alloc_get(NVS_TYPE_STR,key );
 	ESP_LOGD(TAG,"Register default called with:  %s= %s",key,value );
 	if(!existing) {
-		ESP_LOGI(TAG,"Registering default value for key %s, value %s",key,value );
-		config_set_default(NVS_TYPE_STR, key,value, 0);
+		ESP_LOGI(TAG,"Registering default value for key %s, value %s", key, value );
+		config_set_default(NVS_TYPE_STR, key, value, 0);
 	}
 	else {
 		ESP_LOGD(TAG,"Value found for %s: %s",key,existing );


### PR DESCRIPTION
- use gettime_ms() which already exist (and time_t is an epoch so it's not really suitable)
- remove CONFIG_SQUEEZEAMP which is target specific
- eliminate warnings when they are in our code
- the PARSE_PARAM_XXX using function instead of macros is a total gain of less than 500 bytes. As the code does not work due to pointer usage, I've removed it. I tried to use _Generic() as we are C11, but it does not gain anything