### PR TITLE
Add support for AW9523 GPIO expander

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ The parameter "gpio_exp_config" is a semicolon (;) separated list with following
 ```
 model=<model>,addr=<addr>,[,port=system|dac][,base=<n>][,count=<n>][,intr=<gpio>][,cs=<gpio>][,speed=<Hz>]
 ```	
-- model: pca9535, pca85xx, mcp23017 and mcp23s17 (SPI version)
+- model: pca9535, pca85xx, mcp23017, aw9523 and mcp23s17 (SPI version)
 - addr: chip i2c/spi address (decimal)
 - port (I2C): use either "system" port (shared with display for example) or "dac" port (system is default)
 - cs (SPI): gpio used for Chip Select

--- a/components/services/gpio_exp.c
+++ b/components/services/gpio_exp.c
@@ -689,7 +689,9 @@ static void aw9523_set_direction(gpio_exp_t* self) {
 }
 
 static uint32_t aw9523_read(gpio_exp_t* self) {
-	return i2c_read(self->phy.port, self->phy.addr, 0x00, 2);
+	// Reading both registers in one go does not seem to reset IRQ correctly
+	uint8_t port1 = i2c_read(self->phy.port, self->phy.addr, 0x00, 1);
+	return (i2c_read(self->phy.port, self->phy.addr, 0x01, 1) << 8) | port1;
 }
 
 static void aw9523_write(gpio_exp_t* self) {

--- a/components/services/gpio_exp.c
+++ b/components/services/gpio_exp.c
@@ -83,6 +83,10 @@ static void      mcp23s17_set_direction(gpio_exp_t* self);
 static uint32_t  mcp23s17_read(gpio_exp_t* self);
 static void      mcp23s17_write(gpio_exp_t* self);
 
+static void 	aw9523_set_direction(gpio_exp_t* self);
+static uint32_t aw9523_read(gpio_exp_t* self);
+static void 	aw9523_write(gpio_exp_t* self);
+
 static void   service_handler(void *arg);
 static void   debounce_handler( TimerHandle_t xTimer );
 
@@ -130,6 +134,11 @@ static const struct gpio_exp_model_s {
 	  .set_pull_mode = mcp23s17_set_pull_mode,
 	  .read = mcp23s17_read,
 	  .write = mcp23s17_write, },
+	{ .model = "aw9523",
+	  .trigger = GPIO_INTR_LOW_LEVEL,
+	  .set_direction = aw9523_set_direction,
+	  .read = aw9523_read,
+	  .write = aw9523_write, },
 };
 
 static EXT_RAM_ATTR uint8_t n_expanders;
@@ -669,6 +678,22 @@ static uint32_t mcp23s17_read(gpio_exp_t* self) {
 
 static void mcp23s17_write(gpio_exp_t* self) {
 	spi_write(self->spi_handle, self->phy.addr, 0x12, self->shadow, 2);
+}
+
+/****************************************************************************************
+ * AW9523 family : direction, read and write
+ */
+static void aw9523_set_direction(gpio_exp_t* self) {
+	i2c_write(self->phy.port, self->phy.addr, 0x04, self->r_mask, 2);
+	i2c_write(self->phy.port, self->phy.addr, 0x06, ~self->r_mask, 2);
+}
+
+static uint32_t aw9523_read(gpio_exp_t* self) {
+	return i2c_read(self->phy.port, self->phy.addr, 0x00, 2);
+}
+
+static void aw9523_write(gpio_exp_t* self) {
+	i2c_write(self->phy.port, self->phy.addr, 0x02, self->shadow, 2);
 }
 
 /***************************************************************************************


### PR DESCRIPTION
An existing PCB I want to use squeezelite-esp32 with uses an AW9523 as it's GPIO expander. As the register layout differs from the other options, I added the requisite read/write/direction functions.
Tested it with the PCB, outputs and button inputs seem to work fine.