### PR TITLE
Fix for ESP32 equalizer settings don't update when expected

### DIFF
--- a/components/squeezelite/equalizer.c
+++ b/components/squeezelite/equalizer.c
@@ -159,8 +159,7 @@ void equalizer_set_gain(int8_t *gain) {
 	config[n-1] = '\0';
 	config_set_value(NVS_TYPE_STR, "equalizer", config);
     
-    // update only if something changed
-    if (!memcmp(equalizer.gain, gain, EQ_BANDS)) equalizer.update = true;
+    equalizer.update = true;
 
     LOG_INFO("equalizer gain %s", config);
 #else

--- a/components/squeezelite/equalizer.c
+++ b/components/squeezelite/equalizer.c
@@ -22,7 +22,8 @@ static EXT_RAM_ATTR struct {
 	void *handle;
     float loudness, volume;
     uint32_t samplerate;
-	float gain[EQ_BANDS], loudness_gain[EQ_BANDS];
+	int8_t gain[EQ_BANDS];
+	float loudness_gain[EQ_BANDS];
 	bool update;
 } equalizer;
 
@@ -151,6 +152,8 @@ void equalizer_set_gain(int8_t *gain) {
     char config[EQ_BANDS * 4 + 1] = { };
 	int n = 0;
     
+    if (memcmp(equalizer.gain, gain, EQ_BANDS) != 0) equalizer.update = true;
+    
     for (int i = 0; i < EQ_BANDS; i++) {
 		equalizer.gain[i] = gain[i];
 		n += sprintf(config + n, "%d,", gain[i]);
@@ -159,8 +162,6 @@ void equalizer_set_gain(int8_t *gain) {
 	config[n-1] = '\0';
 	config_set_value(NVS_TYPE_STR, "equalizer", config);
     
-    equalizer.update = true;
-
     LOG_INFO("equalizer gain %s", config);
 #else
     LOG_INFO("no equalizer with 32 bits samples");

--- a/components/squeezelite/equalizer.c
+++ b/components/squeezelite/equalizer.c
@@ -148,18 +148,28 @@ void equalizer_set_volume(unsigned left, unsigned right) {
  */
 void equalizer_set_gain(int8_t *gain) {
 #if BYTES_PER_FRAME == 4
+    static uint8_t last_gain[EQ_BANDS] = { };
+    bool eq_update = false;
+
     char config[EQ_BANDS * 4 + 1] = { };
 	int n = 0;
     
     for (int i = 0; i < EQ_BANDS; i++) {
 		equalizer.gain[i] = gain[i];
 		n += sprintf(config + n, "%d,", gain[i]);
+		
+		if (gain[i] != last_gain[i])
+		{
+            eq_update = true;
+		}
+		last_gain[i] = gain[i];
 	}
 
 	config[n-1] = '\0';
 	config_set_value(NVS_TYPE_STR, "equalizer", config);
     
-    equalizer.update = true;
+    //"or" in this value in case equalizer.update is set for another reason
+    equalizer.update |= eq_update;
 
     LOG_INFO("equalizer gain %s", config);
 #else

--- a/components/squeezelite/equalizer.c
+++ b/components/squeezelite/equalizer.c
@@ -148,28 +148,18 @@ void equalizer_set_volume(unsigned left, unsigned right) {
  */
 void equalizer_set_gain(int8_t *gain) {
 #if BYTES_PER_FRAME == 4
-    static uint8_t last_gain[EQ_BANDS] = { };
-    bool eq_update = false;
-
     char config[EQ_BANDS * 4 + 1] = { };
 	int n = 0;
     
     for (int i = 0; i < EQ_BANDS; i++) {
 		equalizer.gain[i] = gain[i];
 		n += sprintf(config + n, "%d,", gain[i]);
-		
-		if (gain[i] != last_gain[i])
-		{
-            eq_update = true;
-		}
-		last_gain[i] = gain[i];
 	}
 
 	config[n-1] = '\0';
 	config_set_value(NVS_TYPE_STR, "equalizer", config);
     
-    //"or" in this value in case equalizer.update is set for another reason
-    equalizer.update |= eq_update;
+    equalizer.update = true;
 
     LOG_INFO("equalizer gain %s", config);
 #else


### PR DESCRIPTION
I confirmed through inserting log statements that the equalizer settings do not update correctly as described in issue #426.

Here is the relevant code in components/squeezelite/equalizer.c

`void equalizer_set_gain(int8_t *gain) {
#if BYTES_PER_FRAME == 4
    char config[EQ_BANDS * 4 + 1] = { };
	int n = 0;
    
    for (int i = 0; i < EQ_BANDS; i++) {
		equalizer.gain[i] = gain[i];
		n += sprintf(config + n, "%d,", gain[i]);
	}

	config[n-1] = '\0';
	config_set_value(NVS_TYPE_STR, "equalizer", config);
    
    // update only if something changed
    if (!memcmp(equalizer.gain, gain, EQ_BANDS)) equalizer.update = true;
`

The update logic does not work as intended for a few of reasons:
- the for loop above sets equalizer.gain = gain (eg: previous value of equalizer.gain is overwritten)
- equalizer.gain is an array of floats, but gain is an array of int8_t and since the types are different memcmp will not work
- memcmp can return a negative value when unequal, and the logical negation (!) of a negative value does not evaluate to true

This PR removes that check and always updates the equalizer when this function is called.  I think this is a valid way to proceed because:
- due to the type mismatch between gain and equalizer.gain, it is messy to see if the old values are different than the new ones.  
- the equalizer update call is not that expensive
- I tested the Material web UI, and it only sends an update request once per time that the UI settings change (eg: this function is not being spammed)