### PR TITLE
Raspiaudio Muse Luxe 2025/11/26

### DIFF
--- a/components/services/monitor.c
+++ b/components/services/monitor.c
@@ -248,7 +248,8 @@ void monitor_svc_init(void) {
 	// re-use button management for jack handler, it's a GPIO after all
 	if (jack.gpio != -1) {
 		ESP_LOGI(TAG,"Adding jack (%s) detection GPIO %d", jack.active ? "high" : "low", jack.gpio);
-		button_create(NULL, jack.gpio, jack.active ? BUTTON_HIGH : BUTTON_LOW, false, 250, jack_handler_default, 0, -1);
+		// Use GPIO pull so the line does not float (Muse jack detect is active-low and needs pull-up)
+		button_create(NULL, jack.gpio, jack.active ? BUTTON_HIGH : BUTTON_LOW, true, 250, jack_handler_default, 0, -1);
 	}
 
 #ifdef CONFIG_SPKFAULT_GPIO_LEVEL

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -129,7 +129,7 @@ menu "Squeezelite-ESP32"
 		config DAC_CONTROLSET
 			string
 			default "{ \"init\": [ {\"reg\":41, \"val\":128}, {\"reg\":18, \"val\":255} ], \"poweron\": [ {\"reg\":18, \"val\":64, \"mode\":\"or\"} ], \"poweroff\": [ {\"reg\":18, \"val\":191, \"mode\":\"and\"} ] }" if TWATCH2020
-			default "{\"init\":[ {\"reg\":0,\"val\":128}, {\"reg\":0,\"val\":0}, {\"reg\":25,\"val\":4}, {\"reg\":1,\"val\":80}, {\"reg\":2,\"val\":0},	{\"reg\":8,\"val\":0}, {\"reg\":4,\"val\":192},	{\"reg\":0,\"val\":18}, {\"reg\":1,\"val\":0}, {\"reg\":23,\"val\":24}, {\"reg\":24,\"val\":2}, {\"reg\":38,\"val\":9}, {\"reg\":39,\"val\":144}, {\"reg\":42,\"val\":144}, {\"reg\":43,\"val\":128}, {\"reg\":45,\"val\":128}, {\"reg\":27,\"val\":0}, {\"reg\":26,\"val\":0}, {\"reg\":2,\"val\":240}, {\"reg\":2,\"val\":0},	{\"reg\":29,\"val\":28}, {\"reg\":4,\"val\":48}, {\"reg\":25,\"val\":0}, {\"reg\":46,\"val\":33}, {\"reg\":47,\"val\":33} ]}" if MUSE
+			default "{\"init\":[ {\"reg\":0,\"val\":128}, {\"reg\":0,\"val\":0}, {\"reg\":25,\"val\":4}, {\"reg\":1,\"val\":80}, {\"reg\":2,\"val\":0},	{\"reg\":8,\"val\":0}, {\"reg\":4,\"val\":192},	{\"reg\":0,\"val\":18}, {\"reg\":1,\"val\":0}, {\"reg\":23,\"val\":24}, {\"reg\":24,\"val\":2}, {\"reg\":38,\"val\":9}, {\"reg\":39,\"val\":144}, {\"reg\":42,\"val\":144}, {\"reg\":43,\"val\":128}, {\"reg\":45,\"val\":128}, {\"reg\":27,\"val\":0}, {\"reg\":26,\"val\":0}, {\"reg\":2,\"val\":240}, {\"reg\":2,\"val\":0},	{\"reg\":29,\"val\":28}, {\"reg\":4,\"val\":60}, {\"reg\":25,\"val\":0}, {\"reg\":46,\"val\":33}, {\"reg\":47,\"val\":33} , {\"reg\":48,\"val\":33}, {\"reg\":49,\"val\":33}]}" if MUSE
 			default ""		
 		config AUDIO_CONTROLS
 			string
@@ -153,7 +153,8 @@ menu "Squeezelite-ESP32"
 			default -1			
 		config JACK_GPIO
 			int
-			default 34 if SQUEEZEAMP || MUSE
+			default 27 if MUSE
+			default 34 if SQUEEZEAMP
 			default -1			
 		config SPKFAULT_GPIO
 			int


### PR DESCRIPTION
The modifications concern the Muse Luxe from RaspiAudio.

This involves enabling the headphone jack for use with headphones.

Two files are slightly modified:

- Kconfig.projbuild
To correct the jack's GPIO pin number.

To enable and amplify output 2 during ES8388 initialization.

- monitor.c
To enable the jack's GPIO pull-up resistor to ensure proper recognition when the jack is removed.