### PR TITLE
fix: avoid recovery after intentional LMS reboot

### DIFF
--- a/components/platform_console/app_squeezelite/cmd_squeezelite.c
+++ b/components/platform_console/app_squeezelite/cmd_squeezelite.c
@@ -85,6 +85,8 @@ static void squeezelite_thread(void *arg){
         wait_for_commit();
         cmd_send_messaging("cfg-audio-tmpl",MESSAGING_ERROR,"Rebooting in %d sec\n", wait);
         vTaskDelay( pdMS_TO_TICKS(wait * 1000));
+        ESP_LOGW(TAG, "Deliberate Squeezelite restart; resetting boot-loop counter");
+        halSTORAGE_RebootCounterUpdate(0);
         esp_restart();
     } else {
 		cmd_send_messaging("cfg-audio-tmpl",MESSAGING_ERROR,"Correct command line and reboot\n");

--- a/components/tools/platform_esp32.h
+++ b/components/tools/platform_esp32.h
@@ -27,6 +27,7 @@
 #define SQUEEZELITE_ESP32_RELEASE_URL "https://github.com/sle118/squeezelite-esp32/releases"
 #endif
 extern bool is_recovery_running;
+extern uint32_t halSTORAGE_RebootCounterUpdate(int32_t xValue);
 extern  bool wait_for_wifi();
 extern bool console_push(const char * data, size_t size);
 extern void console_start();


### PR DESCRIPTION
Fixes #571.

Squeezelite intentionally reboots after an extended inability to reach LMS.
Those intentional restarts currently contribute to the boot-loop counter and
can eventually force the recovery partition.

This change prevents only the intentional no-LMS restart from accumulating
toward recovery. Existing recovery behavior for genuine failures remains
unchanged.

Tested on:

- Sonocotta Louder Esparagus
- ESP32 / W5500 Ethernet
- I2S-4MFlash, 16-bit
- Music Assistant as the LMS/Slimproto server

Test procedure:

1. Booted normally over W5500 and connected to Music Assistant.
2. Made the configured LMS server unavailable.
3. Allowed repeated automatic Squeezelite restart/reboot cycles.
4. Verified the normal application continued to boot instead of entering the
   recovery partition.
5. Restored Music Assistant.
6. Verified the player automatically reconnected over Ethernet.
